### PR TITLE
Set klipper to run with a higher priority

### DIFF
--- a/scripts/install_klipper.sh
+++ b/scripts/install_klipper.sh
@@ -87,6 +87,7 @@ WantedBy=multi-user.target
 Type=simple
 User=$USER
 RemainAfterExit=yes
+Nice=-19
 ExecStart=${KLIPPY_ENV}/bin/python ${KLIPPER_DIR}/klippy/klippy.py ${PRINTER_CFG} -l ${KLIPPER_LOG} -a ${KLIPPY_UDS}
 Restart=always
 RestartSec=10


### PR DESCRIPTION
This fixes issues caused by the load of a USB camera and possibility RPI camera.
Until I did this on a RPI3B+ I was getting MCU timeout issues.