### PR TITLE
More accurate moonraker service search

### DIFF
--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -99,7 +99,7 @@ moonraker_status(){
   )
 
   ### count amount of moonraker service files in /etc/systemd/system
-  SERVICE_FILE_COUNT=$(ls /etc/systemd/system | grep -E "moonraker" | wc -l)
+  SERVICE_FILE_COUNT=$(ls /etc/systemd/system | grep -E 'moonraker\.service|moonraker-[[:digit:]]*.service' | wc -l)
 
   ### remove the "SERVICE" entry from the moonraker_data array if a moonraker service is installed
   [ $SERVICE_FILE_COUNT -gt 0 ] && unset moonraker_data[0]


### PR DESCRIPTION
Old `ls /etc/systemd/system | grep 'moonraker'` can count as a service other moonraker clients.
```
pi@raspberrypi:~ $ ls /etc/systemd/system | grep 'moonraker'
moonraker-1.service
moonraker-2.service
moonraker-telegram-bot.service
```
So this commit makes it work correctly
```
pi@raspberrypi:~ $ ls /etc/systemd/system | grep -E 'moonraker\.service|moonraker-[[:digit:]]*.service'
moonraker-1.service
moonraker-2.service
```