### PR TITLE
PR Submenu change from "quit" to "back"

### DIFF
--- a/scripts/ui/advanced_menu.sh
+++ b/scripts/ui/advanced_menu.sh
@@ -18,7 +18,7 @@ advanced_ui(){
   echo -e "|  6) [Get MCU ID]          |                           | "
   echo -e "|                           |  CustomPiOS:              | "
   echo -e "|                           |  10) [Migration Helper]   | "
-quit_footer
+back_footer
 }
 
 advanced_menu(){
@@ -72,7 +72,7 @@ advanced_menu(){
         do_action "setup_gcode_shell_command" "advanced_ui";;
       10)
         do_action "migration_menu";;
-      Q|q)
+      B|b)
         clear; main_menu; break;;
       *)
         deny_action "advanced_ui";;
@@ -99,7 +99,7 @@ switch_ui(){
   echo -e "|  dmbutyugin:                                          | "
   echo -e "|  2) [--> scurve-shaping]                              | "
   echo -e "|  3) [--> scurve-smoothing]                            | "
-  quit_footer
+  back_footer
 }
 
 switch_menu(){
@@ -137,7 +137,7 @@ switch_menu(){
           read_branch
           print_msg && clear_msg
           switch_ui;;
-        Q|q)
+        B|b)
           clear; advanced_menu; break;;
         *)
           deny_action "switch_ui";;
@@ -167,7 +167,7 @@ rollback_ui(){
   hr
   echo -e "|  Commit last updated from:                            | "
   echo -e "|  $PREV_UI                             | "
-  quit_footer
+  back_footer
 }
 
 #############################################################
@@ -190,7 +190,7 @@ migration_ui(){
   echo -e "|  1) [Migrate MainsailOS]                              | "
   echo -e "|  2) [Migrate FluiddPi]                                | "
   echo -e "|                                                       | "
-  quit_footer
+  back_footer
 }
 
 migration_menu(){
@@ -201,7 +201,7 @@ migration_menu(){
     case "$action" in
       1) migrate_custompios "mainsail"; migration_menu;;
       2) migrate_custompios "fluiddpi"; migration_menu;;
-      Q|q) clear; advanced_menu; break;;
+      B|b) clear; advanced_menu; break;;
       *) print_unkown_cmd; migration_menu;;
     esac
   done

--- a/scripts/ui/backup_menu.sh
+++ b/scripts/ui/backup_menu.sh
@@ -14,7 +14,7 @@ backup_ui(){
   echo -e "|  2) [Moonraker]        |  Other:                      | "
   echo -e "|  3) [Moonraker DB]     |  7) [Duet Web Control]       | "
   echo -e "|                        |  8) [OctoPrint]              | "
-  quit_footer
+  back_footer
 }
 
 backup_menu(){
@@ -40,7 +40,7 @@ backup_menu(){
         do_action "backup_dwc2" "backup_ui";;
       8)
         do_action "backup_octoprint" "backup_ui";;
-      Q|q)
+      B|b)
         clear; main_menu; break;;
       *)
         deny_action "backup_ui";;

--- a/scripts/ui/general_ui.sh
+++ b/scripts/ui/general_ui.sh
@@ -21,6 +21,12 @@ quit_footer(){
   bottom_border
 }
 
+back_footer(){
+  hr
+  echo -e "|                        ${green}B) Back${default}                        | "
+  bottom_border
+}
+
 print_header(){
   top_border
   echo -e "|     $(title_msg "~~~~~~~~~~~~~~~~~ [ KIAUH ] ~~~~~~~~~~~~~~~~~")     |"

--- a/scripts/ui/install_menu.sh
+++ b/scripts/ui/install_menu.sh
@@ -17,7 +17,7 @@ install_ui(){
   echo -e "|  4) [Fluidd]              |  Webcam:                  | "
   echo -e "|                           |  9) [MJPG-Streamer]       | "
   echo -e "|                           |                           | "
-  quit_footer
+  back_footer
 }
 
 install_menu(){
@@ -43,7 +43,7 @@ install_menu(){
         do_action "install_pgc_for_klipper" "install_ui";;
       9)
         do_action "install_mjpg-streamer" "install_ui";;
-      Q|q)
+      B|b)
         clear; main_menu; break;;
       *)
         deny_action "install_ui";;

--- a/scripts/ui/remove_menu.sh
+++ b/scripts/ui/remove_menu.sh
@@ -17,7 +17,7 @@ remove_ui(){
   echo -e "|  3) [Mainsail]            |  9) [PrettyGCode]         | "
   echo -e "|  4) [Fluidd]              |                           | "
   echo -e "|                           | 10) [NGINX]               | "
-  quit_footer
+  back_footer
 }
 
 remove_menu(){
@@ -45,7 +45,7 @@ remove_menu(){
         do_action "remove_prettygcode" "remove_ui";;
       10)
         do_action "remove_nginx" "remove_ui";;
-      Q|q)
+      B|b)
         clear; main_menu; break;;
       *)
         deny_action "remove_ui";;

--- a/scripts/ui/settings_menu.sh
+++ b/scripts/ui/settings_menu.sh
@@ -20,7 +20,7 @@ settings_ui(){
   else
   echo -e "|  1) Change config folder                              | "
   fi
-  quit_footer
+  back_footer
 }
 
 settings_menu(){
@@ -34,7 +34,7 @@ settings_menu(){
         else
           deny_action "settings_ui"
         fi;;
-      Q|q)
+      B|b)
         clear; main_menu; break;;
       *)
         deny_action "settings_ui";;

--- a/scripts/ui/update_menu.sh
+++ b/scripts/ui/update_menu.sh
@@ -24,7 +24,7 @@ update_ui(){
   echo -e "|  8) [PrettyGCode]      |  $LOCAL_PGC_COMMIT | $REMOTE_PGC_COMMIT | "
   echo -e "|                        |------------------------------| "
   echo -e "|  9) [System]           |  $DISPLAY_SYS_UPDATE   | "
-  quit_footer
+  back_footer
 }
 
 update_menu(){
@@ -55,7 +55,7 @@ update_menu(){
         do_action "update_system" "update_ui";;
       a)
         do_action "update_all" "update_ui";;
-      Q|q)
+      B|b)
         clear; main_menu; break;;
       *)
         deny_action "update_ui";;

--- a/scripts/upload_log.sh
+++ b/scripts/upload_log.sh
@@ -71,7 +71,7 @@ upload_selection(){
     printf "|  $i) %-50s|\n" "${logfiles[$i]}"
     i=$((i + 1))
   done
-  quit_footer
+  back_footer
   while true; do
     read -p "${cyan}Please select:${default} " choice
     if [ $choice = "q" ] || [ $choice = "Q" ]; then


### PR DESCRIPTION
When I first ran the code, I went to advanced because I had klipper already installed and I wanted to see if I could install fluidd using this code base. So when see advanced menu I was concerned that "quit" meant quitting the tool instead of exiting the advanced menu. So proposing a back_footer for sub menus that will revert back to main menu. You would use the quit footer for main menu to exit program.

changed submenus to use back_footer
edited general_ui to add back_footer as a UI component