### PR TITLE
Don't restart webcamd service if fail.

### DIFF
--- a/resources/webcamd.service
+++ b/resources/webcamd.service
@@ -13,4 +13,3 @@ StandardOutput=append:/var/log/webcamd.log
 StandardError=append:/var/log/webcamd.log
 ExecStart=/usr/local/bin/webcamd
 Restart=always
-RestartSec=10


### PR DESCRIPTION
Related to [Issue#127](https://github.com/th33xitus/kiauh/issues/127).
Fail the webcamd service startup if there is no webcam present. 
If the script is allowed to restart the service every 10 seconds, the logs eventually fill up.