### PR TITLE
Use `[[:digit:]]` instead of `\d`

### DIFF
--- a/scripts/install_klipper_webui.sh
+++ b/scripts/install_klipper_webui.sh
@@ -332,7 +332,7 @@ mainsail_setup(){
   rm -rf *.zip && ok_msg "Done!"
 
   ### check for moonraker multi-instance and if multi-instance was found, enable mainsails remoteMode
-  if [ $(ls /etc/systemd/system/moonraker* | grep -E "moonraker(-\d+)?\.service" | wc -l) -gt 1 ]; then
+  if [ $(ls /etc/systemd/system/moonraker* | grep -E "moonraker(-[[:digit:]]+)?\.service" | wc -l) -gt 1 ]; then
     enable_mainsail_remotemode
   fi
 }


### PR DESCRIPTION
GNU grep in Raspberry Pi OS doesn't seem to support `\d`.

https://www.gnu.org/software/grep/manual/grep.html