### PR TITLE
fix(gcode_shell_command): py3 virtual env compatibility

### DIFF
--- a/resources/gcode_shell_command.py
+++ b/resources/gcode_shell_command.py
@@ -32,7 +32,7 @@ class ShellCommand:
             data = os.read(self.proc_fd, 4096)
         except Exception:
             pass
-        data = self.partial_output + data
+        data = self.partial_output + data.decode()
         if '\n' not in data:
             self.partial_output = data
             return


### PR DESCRIPTION
The change is needed that the module can be used in a python 2 and python 3 virtual env.

Signed-off-by: Alex Zellner alexander.zellner@googlemail.com