### PR TITLE
Fix for issue #199

### DIFF
--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -114,9 +114,8 @@ function read_kiauh_ini() {
   local func=${1}
 
   if [[ ! -f ${INI_FILE} ]]; then
-    print_error "ERROR: File '~/.kiauh.ini' not found!"
-    log_error "Reading from .kiauh.ini failed! File not found!"
-    return 1
+    log_warning "Reading from .kiauh.ini failed! File not found! Creating default ini file."
+    init_ini
   fi
 
   log_info "Reading from .kiauh.ini ... (${func})"


### PR DESCRIPTION
This fixes the issue when there is no ini file present during first run and installing klipper.

The root cause is that the globals are read prior to creation of the ini file, but the code that initializes the globals is looking for the ini file via the read_kiauh_ini function. So we create the ini there on-demand if it's missing