### PR TITLE
Calculate pause position from config

### DIFF
--- a/resources/kiauh_macros.cfg
+++ b/resources/kiauh_macros.cfg
@@ -21,8 +21,8 @@ gcode:
 rename_existing: BASE_PAUSE
 gcode:
     ##### set defaults #####
-    {% set x = params.X|default(230) %}      #edit to your park position
-    {% set y = params.Y|default(230) %}      #edit to your park position
+    {% set x = params.X|default(printer.toolhead.axis_maximum.x - 5) %}      #edit to your park position
+    {% set y = params.Y|default(printer.toolhead.axis_maximum.y - 5) %}      #edit to your park position
     {% set z = params.Z|default(10)|float %} #edit to your park position
     {% set e = params.E|default(1) %}        #edit to your retract length
     ##### calculate save lift position #####


### PR DESCRIPTION
Reads printer.toolhead.axis_maximum for X and Y pause position, so this macro should just work for most printers.

We're already doing this for z-max, so why not do this? I think it's pretty readable.