### PR TITLE
Enable to install Mainsail / Fluidd without Moonraker

### DIFF
--- a/scripts/fluidd.sh
+++ b/scripts/fluidd.sh
@@ -19,7 +19,21 @@ function install_fluidd() {
   ### exit early if moonraker not found
   if [[ -z $(moonraker_systemd) ]]; then
     local error="Moonraker not installed! Please install Moonraker first!"
-    print_error "${error}" && return
+    print_error "${error}"
+    while true; do
+      read -p "${cyan}###### Install Fluidd without Moonraker? (Y/n):${white} " yn
+      case "${yn}" in
+        Y|y|Yes|yes|"")
+          select_msg "Yes"
+          break;;
+        N|n|No|no)
+          select_msg "No"
+          abort_msg "Exiting Fluidd setup ...\n"
+          return;;
+        *)
+          error_msg "Invalid Input!";;
+      esac
+    done
   fi
 
   ### checking dependencies

--- a/scripts/mainsail.sh
+++ b/scripts/mainsail.sh
@@ -19,7 +19,21 @@ function install_mainsail() {
   ### exit early if moonraker not found
   if [[ -z $(moonraker_systemd) ]]; then
     local error="Moonraker not installed! Please install Moonraker first!"
-    print_error "${error}" && return
+    print_error "${error}"
+    while true; do
+      read -p "${cyan}###### Install Mainsail without Moonraker? (Y/n):${white} " yn
+      case "${yn}" in
+        Y|y|Yes|yes|"")
+          select_msg "Yes"
+          break;;
+        N|n|No|no)
+          select_msg "No"
+          abort_msg "Exiting Mainsail setup ...\n"
+          return;;
+        *)
+          error_msg "Invalid Input!";;
+      esac
+    done
   fi
 
   ### checking dependencies


### PR DESCRIPTION
This allows the user to install Mainsail / Fluidd without Moonraker in order to configure separate frontend and backend architecture.

(1) Moonraker is not installed on localhost when installing Mainsail or Fluidd, it shows prompt to confirm install without Moonraker.
<img width="420" alt="pict1" src="https://user-images.githubusercontent.com/1912821/197051136-0bbee78e-d904-4417-b34f-9a01f537ad8b.png">

(2) It shows prompts to setup an apiserver into `/etc/nginx/conf.d/upstreams.conf`.
<img width="420" alt="pict2" src="https://user-images.githubusercontent.com/1912821/197051170-0a5cf487-fa75-4e77-a37f-f356a4858260.png">
