### PR TITLE
fix: pull mainsail.cfg from correct location

### DIFF
--- a/scripts/mainsail.sh
+++ b/scripts/mainsail.sh
@@ -126,7 +126,7 @@ function install_mainsail_macros() {
 function download_mainsail_macros() {
   local ms_cfg path configs regex
 
-  ms_cfg="https://raw.githubusercontent.com/mainsail-crew/MainsailOS/master/src/modules/mainsail/filesystem/home/pi/klipper_config/mainsail.cfg"
+  ms_cfg="https://raw.githubusercontent.com/mainsail-crew/mainsail-config/master/mainsail.cfg"
   regex="\/home\/${USER}\/([A-Za-z0-9_]+)\/config\/printer\.cfg"
   configs=$(find "${HOME}" -maxdepth 3 -regextype posix-extended -regex "${regex}" | sort)
 


### PR DESCRIPTION
Mainsail has split its repositories and the configuration is now in its own repo. This fix aims to allow pulling the new configuration file which fixes Moonraker complaining about the gcode path not being correct : 

```
Moonraker warning

GCode path received from Klipper does not match expected location.

Received: '/home/pi/gcode_files'
Expected: '/home/pi/printer_data/gcodes'

Modify the [virtual_sdcard] section Klipper's configuration to correct this error.

[virtual_sdcard]
path: /home/pi/printer_data/gcodes
```