### PR TITLE
fix(mainsail): set increased read timeout on API endpoint

### DIFF
--- a/resources/fluidd
+++ b/resources/fluidd
@@ -55,6 +55,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Scheme $scheme;
+        proxy_read_timeout 600;
     }
 
     location /webcam/ {

--- a/resources/mainsail
+++ b/resources/mainsail
@@ -55,6 +55,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Scheme $scheme;
+        proxy_read_timeout 600;
     }
 
     location /webcam/ {


### PR DESCRIPTION
An increased timeout needs to be set on API endpoint. Having default 60s means that, especially, on weaker/slower systems, and especially larger Gcode files with object exclusion configured, sending e.g. directly from slicer times out with HTTP 504. 600s seems like a reasonable number.