### PR TITLE
fix(telegram bot): Fix service restart

### DIFF
--- a/resources/moonraker-telegram-bot.service
+++ b/resources/moonraker-telegram-bot.service
@@ -9,7 +9,6 @@ WantedBy=multi-user.target
 [Service]
 Type=simple
 User=%USER%
-RemainAfterExit=yes
 WorkingDirectory=/home/%USER%/moonraker-telegram-bot
 EnvironmentFile=%ENV_FILE%
 ExecStart=%ENV%/bin/python $TELEGRAM_BOT_ARGS


### PR DESCRIPTION
Removed `RemainAfterExit`, as it is not needed for `Type=simple` service, and only cause problems.