### PR TITLE
fix: always use system home directory

### DIFF
--- a/scripts/fluidd.sh
+++ b/scripts/fluidd.sh
@@ -127,7 +127,7 @@ function download_fluidd_macros() {
   local fluidd_cfg path configs regex
 
   fluidd_cfg="https://raw.githubusercontent.com/fluidd-core/FluiddPI/master/src/modules/fluidd/filesystem/home/pi/klipper_config/fluidd.cfg"
-  regex="\/home\/${USER}\/([A-Za-z0-9_]+)\/config\/printer\.cfg"
+  regex="${HOME//\//\\/}\/([A-Za-z0-9_]+)\/config\/printer\.cfg"
   configs=$(find "${HOME}" -maxdepth 3 -regextype posix-extended -regex "${regex}" | sort)
 
   if [[ -n ${configs} ]]; then
@@ -140,7 +140,7 @@ function download_fluidd_macros() {
 
         ### replace user 'pi' with current username to prevent issues in cases where the user is not called 'pi'
         log_info "modify fluidd.cfg"
-        sed -i "/^path: \/home\/pi\/gcode_files/ s/\/home\/pi/\/home\/${USER}/" "${path}/fluidd.cfg"
+        sed -i "/^path: \/home\/pi\/gcode_files/ s/\/home\/pi/${HOME//\//\\/}/" "${path}/fluidd.cfg"
 
         ### write include to the very first line of the printer.cfg
         if ! grep -Eq "^[include fluidd.cfg]$" "${path}/printer.cfg"; then
@@ -218,7 +218,7 @@ function remove_fluidd_logs() {
 function remove_fluidd_log_symlinks() {
   local files regex
 
-  regex="\/home\/${USER}\/([A-Za-z0-9_]+)\/logs\/fluidd-.*"
+  regex="${HOME//\//\\/}\/([A-Za-z0-9_]+)\/logs\/fluidd-.*"
   files=$(find "${HOME}" -maxdepth 3 -regextype posix-extended -regex "${regex}" 2> /dev/null | sort)
 
   if [[ -n ${files} ]]; then
@@ -416,7 +416,7 @@ function select_fluidd_port() {
 
 function patch_fluidd_update_manager() {
   local patched moonraker_configs regex
-  regex="\/home\/${USER}\/([A-Za-z0-9_]+)\/config\/moonraker\.conf"
+  regex="${HOME//\//\\/}\/([A-Za-z0-9_]+)\/config\/moonraker\.conf"
   moonraker_configs=$(find "${HOME}" -maxdepth 3 -type f -regextype posix-extended -regex "${regex}" | sort)
 
   patched="false"

--- a/scripts/gcode_shell_command.sh
+++ b/scripts/gcode_shell_command.sh
@@ -106,7 +106,7 @@ function create_example_shell_command() {
   backup_klipper_config_dir
 
   local configs regex path
-  regex="\/home\/${USER}\/([A-Za-z0-9_]+)\/config\/printer\.cfg"
+  regex="${HOME//\//\\/}\/([A-Za-z0-9_]+)\/config\/printer\.cfg"
   configs=$(find "${HOME}" -maxdepth 3 -regextype posix-extended -regex "${regex}" | sort)
 
   for cfg in ${configs}; do

--- a/scripts/mainsail.sh
+++ b/scripts/mainsail.sh
@@ -99,7 +99,7 @@ function download_mainsail_macros() {
   local ms_cfg_repo path configs regex line gcode_dir
 
   ms_cfg_repo="https://github.com/mainsail-crew/mainsail-config.git"
-  regex="\/home\/${USER}\/([A-Za-z0-9_]+)\/config\/printer\.cfg"
+  regex="${HOME//\//\\/}\/([A-Za-z0-9_]+)\/config\/printer\.cfg"
   configs=$(find "${HOME}" -maxdepth 3 -regextype posix-extended -regex "${regex}" | sort)
 
   if [[ -z ${configs} ]]; then
@@ -223,7 +223,7 @@ function remove_mainsail_logs() {
 function remove_mainsail_log_symlinks() {
   local files regex
 
-  regex="\/home\/${USER}\/([A-Za-z0-9_]+)\/logs\/mainsail-.*"
+  regex="${HOME//\//\\/}\/([A-Za-z0-9_]+)\/logs\/mainsail-.*"
   files=$(find "${HOME}" -maxdepth 3 -regextype posix-extended -regex "${regex}" 2> /dev/null | sort)
 
   if [[ -n ${files} ]]; then
@@ -469,7 +469,7 @@ function ms_theme_install() {
 function ms_theme_delete() {
   local regex theme_folders target_folders=()
 
-  regex="\/home\/${USER}\/([A-Za-z0-9_]+)\/config\/\.theme"
+  regex="${HOME//\//\\/}\/([A-Za-z0-9_]+)\/config\/\.theme"
   theme_folders=$(find "${HOME}" -maxdepth 3 -type d -regextype posix-extended -regex "${regex}" | sort)
 #  theme_folders=$(find "${KLIPPER_CONFIG}" -mindepth 1 -type d -name ".theme" | sort)
 
@@ -603,7 +603,7 @@ function enable_mainsail_remotemode() {
 
 function patch_mainsail_update_manager() {
   local patched moonraker_configs regex
-  regex="\/home\/${USER}\/([A-Za-z0-9_]+)\/config\/moonraker\.conf"
+  regex="${HOME//\//\\/}\/([A-Za-z0-9_]+)\/config\/moonraker\.conf"
   moonraker_configs=$(find "${HOME}" -maxdepth 3 -type f -regextype posix-extended -regex "${regex}" | sort)
 
   patched="false"
@@ -635,7 +635,7 @@ MOONRAKER_CONF
 
 function patch_mainsail_config_update_manager() {
   local patched moonraker_configs regex
-  regex="\/home\/${USER}\/([A-Za-z0-9_]+)\/config\/moonraker\.conf"
+  regex="${HOME//\//\\/}\/([A-Za-z0-9_]+)\/config\/moonraker\.conf"
   moonraker_configs=$(find "${HOME}" -maxdepth 3 -type f -regextype posix-extended -regex "${regex}" | sort)
 
   patched="false"

--- a/scripts/moonraker-telegram-bot.sh
+++ b/scripts/moonraker-telegram-bot.sh
@@ -376,7 +376,7 @@ function remove_telegram_bot_env() {
 }
 
 function remove_telegram_bot_env_file() {
-  local files regex="\/home\/${USER}\/([A-Za-z0-9_]+)\/systemd\/moonraker-telegram-bot\.env"
+  local files regex="${HOME//\//\\/}\/([A-Za-z0-9_]+)\/systemd\/moonraker-telegram-bot\.env"
   files=$(find "${HOME}" -maxdepth 3 -regextype posix-extended -regex "${regex}" | sort)
 
   if [[ -n ${files} ]]; then
@@ -389,7 +389,7 @@ function remove_telegram_bot_env_file() {
 }
 
 function remove_telegram_bot_logs() {
-  local files regex="\/home\/${USER}\/([A-Za-z0-9_]+)\/logs\/telegram\.log.*"
+  local files regex="${HOME//\//\\/}\/([A-Za-z0-9_]+)\/logs\/telegram\.log.*"
   files=$(find "${HOME}" -maxdepth 3 -regextype posix-extended -regex "${regex}" | sort)
 
   if [[ -n ${files} ]]; then
@@ -519,7 +519,7 @@ function compare_telegram_bot_versions() {
 
 function patch_telegram_bot_update_manager() {
   local patched moonraker_configs regex
-  regex="\/home\/${USER}\/([A-Za-z0-9_]+)\/config\/moonraker\.conf"
+  regex="${HOME//\//\\/}\/([A-Za-z0-9_]+)\/config\/moonraker\.conf"
   moonraker_configs=$(find "${HOME}" -maxdepth 3 -type f -regextype posix-extended -regex "${regex}" | sort)
 
   patched="false"

--- a/scripts/moonraker.sh
+++ b/scripts/moonraker.sh
@@ -465,7 +465,7 @@ function remove_moonraker_systemd() {
 }
 
 function remove_moonraker_env_file() {
-  local files regex="\/home\/${USER}\/([A-Za-z0-9_]+)\/systemd\/moonraker\.env"
+  local files regex="${HOME//\//\\/}\/([A-Za-z0-9_]+)\/systemd\/moonraker\.env"
   files=$(find "${HOME}" -maxdepth 3 -regextype posix-extended -regex "${regex}" | sort)
 
   if [[ -n ${files} ]]; then
@@ -478,7 +478,7 @@ function remove_moonraker_env_file() {
 }
 
 function remove_moonraker_logs() {
-  local files regex="\/home\/${USER}\/([A-Za-z0-9_]+)\/logs\/moonraker\.log.*"
+  local files regex="${HOME//\//\\/}\/([A-Za-z0-9_]+)\/logs\/moonraker\.log.*"
   files=$(find "${HOME}" -maxdepth 3 -regextype posix-extended -regex "${regex}" | sort)
 
   if [[ -n ${files} ]]; then

--- a/scripts/nginx.sh
+++ b/scripts/nginx.sh
@@ -79,7 +79,7 @@ function symlink_webui_nginx_log() {
   interface=${1}
   access_log="/var/log/nginx/${interface}-access.log"
   error_log="/var/log/nginx/${interface}-error.log"
-  regex="\/home\/${USER}\/([A-Za-z0-9_]+)\/logs"
+  regex="${HOME//\//\\/}\/([A-Za-z0-9_]+)\/logs"
   logpaths=$(find "${HOME}" -maxdepth 2 -type d -regextype posix-extended -regex "${regex}" | sort)
 
   for path in ${logpaths}; do

--- a/scripts/obico.sh
+++ b/scripts/obico.sh
@@ -311,7 +311,7 @@ function remove_moonraker_obico_systemd() {
 }
 
 function remove_moonraker_obico_logs() {
-  local files regex="\/home\/${USER}\/([A-Za-z0-9_]+)\/logs\/moonraker-obico(-[0-9a-zA-Z]+)?\.log(.*)?"
+  local files regex="${HOME//\//\\/}\/([A-Za-z0-9_]+)\/logs\/moonraker-obico(-[0-9a-zA-Z]+)?\.log(.*)?"
   files=$(find "${HOME}" -maxdepth 3 -regextype posix-extended -regex "${regex}" | sort)
 
   if [[ -n ${files} ]]; then

--- a/scripts/pretty_gcode.sh
+++ b/scripts/pretty_gcode.sh
@@ -38,7 +38,7 @@ function install_pgc_for_klipper() {
   fi
 
   sudo cp "${pgconfsrc}" "${pgconf}"
-  sudo sed -i "s|/home/pi/pgcode;|/home/${USER}/pgcode;|" "${pgconf}"
+  sudo sed -i "s|/home/pi/pgcode;|${HOME}/pgcode;|" "${pgconf}"
 
   ### replace default port
   if (( pgc_custom_port != pgc_default_port )); then


### PR DESCRIPTION
My understanding from the usage of `\/home\/${USER}` around the scripts is to ensure that `/` is escaped to `\/`, but that makes the assumption that `${HOME}` is the same as `\home\${USER}`.

Knowing that we can use `${HOME//pattern/replacement}` we should be able to escape any `/` to `\/` by using `${HOME//\//\\/}`.

This change makes it possible to use Kiauh directly on a docker container with no "\home" folder.