### PR TITLE
fix(crowsnest): override installers BASE_USER to current user

### DIFF
--- a/scripts/crowsnest.sh
+++ b/scripts/crowsnest.sh
@@ -105,7 +105,7 @@ function install_crowsnest(){
   pushd "${HOME}/crowsnest" &> /dev/null || exit 1
   title_msg "Installer will prompt you for sudo password!"
   status_msg "Launching crowsnest installer ..."
-  if ! sudo make install; then
+  if ! sudo make install BASE_USER=$USER; then
     error_msg "Something went wrong! Please try again..."
     exit 1
   fi


### PR DESCRIPTION
The crowsnest installer used `logname` to figure out the current user, this isn't great since it will return the "original" owner of the login session, so if you used `sudo` or `su` to become your klipper user .. it would try to install things into your original user making a bit of a mess ...

The symptoms show up similar to https://github.com/th33xitus/kiauh/issues/302 (not enough details in there to say its exactly the same)