### PR TITLE
fix(klipper): if set, use custom branch to check for update

### DIFF
--- a/scripts/klipper.sh
+++ b/scripts/klipper.sh
@@ -590,8 +590,14 @@ function get_remote_klipper_commit() {
   [[ ! -d ${KLIPPER_DIR} || ! -d "${KLIPPER_DIR}/.git" ]] && return
 
   local commit
+  local branch
+
+  read_kiauh_ini "${FUNCNAME[0]}"
+  branch="${custom_klipper_repo_branch}"
+  [[ -z ${branch} ]] && branch="master"
+
   cd "${KLIPPER_DIR}" && git fetch origin -q
-  commit=$(git describe origin/master --always --tags | cut -d "-" -f 1,2)
+  commit=$(git describe "origin/${branch}" --always --tags | cut -d "-" -f 1,2)
   echo "${commit}"
 }
 


### PR DESCRIPTION
If a custom Klipper repository is not using 'master' as the branch checking for updates will fail or give stale data.

Fix this by checking the custom branch instead.