### PR TITLE
refactor: update package lists only when stale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.vscode
+*.code-workspace
 klipper_repos.txt

--- a/scripts/crowsnest.sh
+++ b/scripts/crowsnest.sh
@@ -197,7 +197,7 @@ function compare_crowsnest_versions() {
 }
 
 function install_crowsnest_dependencies() {
-  local packages
+  local packages log_name="Crowsnest"
   local install_script="${CROWSNEST_DIR}/tools/install.sh"
 
   ### read PKGLIST from official install-script
@@ -208,25 +208,11 @@ function install_crowsnest_dependencies() {
   echo "${cyan}${packages}${white}" | tr '[:space:]' '\n'
     read -r -a packages <<< "${packages}"
 
-  ### Update system package info if lists > 3 days old
-  status_msg "Updating package lists..."
-  if [[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mtime -3)" ]]; then
-    if ! sudo apt-get update --allow-releaseinfo-change; then
-      log_error "failure while updating package lists"
-      error_msg "Updating package lists failed!"
-      exit 1
-    fi
-  else
-    status_msg "Package lists updated recently, skipping..."
-  fi
+  ### Update system package lists if stale
+  update_system_package_lists
 
   ### Install required packages
-  status_msg "Installing required packages..."
-  if ! sudo apt-get install --yes "${packages[@]}"; then
-    log_error "failure while installing required crowsnest packages"
-    error_msg "Installing required packages failed!"
-    exit 1
-  fi
+  install_system_packages "$log_name" "packages[@]"
 }
 
 function update_crowsnest() {

--- a/scripts/crowsnest.sh
+++ b/scripts/crowsnest.sh
@@ -212,7 +212,7 @@ function install_crowsnest_dependencies() {
   update_system_package_lists
 
   ### Install required packages
-  install_system_packages "$log_name" "packages[@]"
+  install_system_packages "${log_name}" "packages[@]"
 }
 
 function update_crowsnest() {

--- a/scripts/crowsnest.sh
+++ b/scripts/crowsnest.sh
@@ -208,12 +208,16 @@ function install_crowsnest_dependencies() {
   echo "${cyan}${packages}${white}" | tr '[:space:]' '\n'
     read -r -a packages <<< "${packages}"
 
-  ### Update system package info
+  ### Update system package info if lists > 3 days old
   status_msg "Updating package lists..."
-  if ! sudo apt-get update --allow-releaseinfo-change; then
-    log_error "failure while updating package lists"
-    error_msg "Updating package lists failed!"
-    exit 1
+  if [[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mtime -3)" ]]; then
+    if ! sudo apt-get update --allow-releaseinfo-change; then
+      log_error "failure while updating package lists"
+      error_msg "Updating package lists failed!"
+      exit 1
+    fi
+  else
+    status_msg "Package lists updated recently, skipping..."
   fi
 
   ### Install required packages

--- a/scripts/klipper.sh
+++ b/scripts/klipper.sh
@@ -325,7 +325,7 @@ function install_klipper_packages() {
   update_system_package_lists
 
   ### Install required packages
-  install_system_packages "$log_name" "packages[@]"
+  install_system_packages "${log_name}" "packages[@]"
 }
 
 function create_klipper_service() {

--- a/scripts/klipper.sh
+++ b/scripts/klipper.sh
@@ -295,7 +295,7 @@ function create_klipper_virtualenv() {
 # @param {string}: python_version - klipper-env python version
 #
 function install_klipper_packages() {
-  local packages python_version="${1}"
+  local packages log_name="Klipper" python_version="${1}"
   local install_script="${KLIPPER_DIR}/scripts/install-debian.sh"
 
   status_msg "Reading dependencies..."
@@ -321,25 +321,11 @@ function install_klipper_packages() {
   echo "${cyan}${packages}${white}" | tr '[:space:]' '\n'
   read -r -a packages <<< "${packages}"
 
-  ### Update system package info if lists > 3 days old
-  status_msg "Updating package lists..."
-  if [[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mtime -3)" ]]; then
-    if ! sudo apt-get update --allow-releaseinfo-change; then
-      log_error "failure while updating package lists"
-      error_msg "Updating package lists failed!"
-      exit 1
-    fi
-  else
-    status_msg "Package lists updated recently, skipping..."
-  fi
+  ### Update system package lists if stale
+  update_system_package_lists
 
   ### Install required packages
-  status_msg "Installing required packages..."
-  if ! sudo apt-get install --yes "${packages[@]}"; then
-    log_error "failure while installing required klipper packages"
-    error_msg "Installing required packages failed!"
-    exit 1
-  fi
+  install_system_packages "$log_name" "packages[@]"
 }
 
 function create_klipper_service() {

--- a/scripts/klipper.sh
+++ b/scripts/klipper.sh
@@ -321,12 +321,16 @@ function install_klipper_packages() {
   echo "${cyan}${packages}${white}" | tr '[:space:]' '\n'
   read -r -a packages <<< "${packages}"
 
-  ### Update system package info
+  ### Update system package info if lists > 3 days old
   status_msg "Updating package lists..."
-  if ! sudo apt-get update --allow-releaseinfo-change; then
-    log_error "failure while updating package lists"
-    error_msg "Updating package lists failed!"
-    exit 1
+  if [[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mtime -3)" ]]; then
+    if ! sudo apt-get update --allow-releaseinfo-change; then
+      log_error "failure while updating package lists"
+      error_msg "Updating package lists failed!"
+      exit 1
+    fi
+  else
+    status_msg "Package lists updated recently, skipping..."
   fi
 
   ### Install required packages

--- a/scripts/moonraker-telegram-bot.sh
+++ b/scripts/moonraker-telegram-bot.sh
@@ -110,7 +110,7 @@ function telegram_bot_setup_dialog() {
 }
 
 function install_telegram_bot_dependencies() {
-  local packages
+  local packages log_name="Telegram Bot"
   local install_script="${TELEGRAM_BOT_DIR}/scripts/install.sh"
 
   ### read PKGLIST from official install-script
@@ -121,25 +121,11 @@ function install_telegram_bot_dependencies() {
   echo "${cyan}${packages}${white}" | tr '[:space:]' '\n'
   read -r -a packages <<< "${packages}"
 
-  ### Update system package info if lists > 3 days old
-  status_msg "Updating package lists..."
-  if [[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mtime -3)" ]]; then
-    if ! sudo apt-get update --allow-releaseinfo-change; then
-      log_error "failure while updating package lists"
-      error_msg "Updating package lists failed!"
-      exit 1
-    fi
-  else
-    status_msg "Package lists updated recently, skipping..."
-  fi
+  ### Update system package lists if stale
+  update_system_package_lists
 
   ### Install required packages
-  status_msg "Installing required packages..."
-  if ! sudo apt-get install --yes "${packages[@]}"; then
-    log_error "failure while installing required moonraker-telegram-bot packages"
-    error_msg "Installing required packages failed!"
-    exit 1
-  fi
+  install_system_packages "$log_name" "packages[@]"
 }
 
 function create_telegram_bot_virtualenv() {

--- a/scripts/moonraker-telegram-bot.sh
+++ b/scripts/moonraker-telegram-bot.sh
@@ -121,12 +121,16 @@ function install_telegram_bot_dependencies() {
   echo "${cyan}${packages}${white}" | tr '[:space:]' '\n'
   read -r -a packages <<< "${packages}"
 
-  ### Update system package info
+  ### Update system package info if lists > 3 days old
   status_msg "Updating package lists..."
-  if ! sudo apt-get update --allow-releaseinfo-change; then
-    log_error "failure while updating package lists"
-    error_msg "Updating package lists failed!"
-    exit 1
+  if [[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mtime -3)" ]]; then
+    if ! sudo apt-get update --allow-releaseinfo-change; then
+      log_error "failure while updating package lists"
+      error_msg "Updating package lists failed!"
+      exit 1
+    fi
+  else
+    status_msg "Package lists updated recently, skipping..."
   fi
 
   ### Install required packages

--- a/scripts/moonraker-telegram-bot.sh
+++ b/scripts/moonraker-telegram-bot.sh
@@ -125,7 +125,7 @@ function install_telegram_bot_dependencies() {
   update_system_package_lists
 
   ### Install required packages
-  install_system_packages "$log_name" "packages[@]"
+  install_system_packages "${log_name}" "packages[@]"
 }
 
 function create_telegram_bot_virtualenv() {

--- a/scripts/moonraker.sh
+++ b/scripts/moonraker.sh
@@ -156,7 +156,7 @@ function install_moonraker_dependencies() {
   update_system_package_lists
 
   ### Install required packages
-  install_system_packages "$log_name" "packages[@]"
+  install_system_packages "${log_name}" "packages[@]"
 }
 
 function create_moonraker_virtualenv() {

--- a/scripts/moonraker.sh
+++ b/scripts/moonraker.sh
@@ -141,7 +141,7 @@ function moonraker_setup_dialog() {
 }
 
 function install_moonraker_dependencies() {
-  local packages
+  local packages log_name="Moonraker"
   local install_script="${MOONRAKER_DIR}/scripts/install-moonraker.sh"
 
   ### read PKGLIST from official install-script
@@ -152,25 +152,11 @@ function install_moonraker_dependencies() {
   echo "${cyan}${packages}${white}" | tr '[:space:]' '\n'
   read -r -a packages <<< "${packages}"
 
-  ### Update system package info if lists > 3 days old
-  status_msg "Updating package lists..."
-  if [[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mtime -3)" ]]; then
-    if ! sudo apt-get update --allow-releaseinfo-change; then
-      log_error "failure while updating package lists"
-      error_msg "Updating package lists failed!"
-      exit 1
-    fi
-  else
-    status_msg "Package lists updated recently, skipping..."
-  fi
+  ### Update system package lists if stale
+  update_system_package_lists
 
   ### Install required packages
-  status_msg "Installing required packages..."
-  if ! sudo apt-get install --yes "${packages[@]}"; then
-    log_error "failure while installing required moonraker packages"
-    error_msg "Installing required packages failed!"
-    exit 1
-  fi
+  install_system_packages "$log_name" "packages[@]"
 }
 
 function create_moonraker_virtualenv() {

--- a/scripts/moonraker.sh
+++ b/scripts/moonraker.sh
@@ -152,12 +152,16 @@ function install_moonraker_dependencies() {
   echo "${cyan}${packages}${white}" | tr '[:space:]' '\n'
   read -r -a packages <<< "${packages}"
 
-  ### Update system package info
+  ### Update system package info if lists > 3 days old
   status_msg "Updating package lists..."
-  if ! sudo apt-get update --allow-releaseinfo-change; then
-    log_error "failure while updating package lists"
-    error_msg "Updating package lists failed!"
-    exit 1
+  if [[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mtime -3)" ]]; then
+    if ! sudo apt-get update --allow-releaseinfo-change; then
+      log_error "failure while updating package lists"
+      error_msg "Updating package lists failed!"
+      exit 1
+    fi
+  else
+    status_msg "Package lists updated recently, skipping..."
   fi
 
   ### Install required packages

--- a/scripts/octoeverywhere.sh
+++ b/scripts/octoeverywhere.sh
@@ -318,12 +318,16 @@ function install_octoeverywhere_dependencies() {
   echo "${cyan}${packages}${white}" | tr '[:space:]' '\n'
   read -r -a packages <<< "${packages}"
 
-  ### Update system package info
+  ### Update system package info if lists > 3 days old
   status_msg "Updating package lists..."
-  if ! sudo apt-get update --allow-releaseinfo-change; then
-    log_error "failure while updating package lists"
-    error_msg "Updating package lists failed!"
-    exit 1
+  if [[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mtime -3)" ]]; then
+    if ! sudo apt-get update --allow-releaseinfo-change; then
+      log_error "failure while updating package lists"
+      error_msg "Updating package lists failed!"
+      exit 1
+    fi
+  else
+    status_msg "Package lists updated recently, skipping..."
   fi
 
   ### Install required packages

--- a/scripts/octoeverywhere.sh
+++ b/scripts/octoeverywhere.sh
@@ -322,7 +322,7 @@ function install_octoeverywhere_dependencies() {
   update_system_package_lists
 
   ### Install required packages
-  install_system_packages "$log_name" "packages[@]"
+  install_system_packages "${log_name}" "packages[@]"
 }
 
 #===================================================#

--- a/scripts/octoeverywhere.sh
+++ b/scripts/octoeverywhere.sh
@@ -307,7 +307,7 @@ function clone_octoeverywhere() {
 }
 
 function install_octoeverywhere_dependencies() {
-  local packages
+  local packages log_name="OctoEverywhere"
   local install_script="${OCTOEVERYWHERE_DIR}/install.sh"
 
   ### read PKGLIST from official install-script
@@ -318,25 +318,11 @@ function install_octoeverywhere_dependencies() {
   echo "${cyan}${packages}${white}" | tr '[:space:]' '\n'
   read -r -a packages <<< "${packages}"
 
-  ### Update system package info if lists > 3 days old
-  status_msg "Updating package lists..."
-  if [[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mtime -3)" ]]; then
-    if ! sudo apt-get update --allow-releaseinfo-change; then
-      log_error "failure while updating package lists"
-      error_msg "Updating package lists failed!"
-      exit 1
-    fi
-  else
-    status_msg "Package lists updated recently, skipping..."
-  fi
+  ### Update system package lists if stale
+  update_system_package_lists
 
   ### Install required packages
-  status_msg "Installing required packages..."
-  if ! sudo apt-get install --yes "${packages[@]}"; then
-    log_error "failure while installing required octoeverywhere packages"
-    error_msg "Installing required packages failed!"
-    exit 1
-  fi
+  install_system_packages "$log_name" "packages[@]"
 }
 
 #===================================================#

--- a/scripts/ui/install_menu.sh
+++ b/scripts/ui/install_menu.sh
@@ -34,7 +34,8 @@ function install_ui() {
 }
 
 function install_menu() {
-  clear && print_header
+  clear -x && sudo -v && clear -x # (re)cache sudo credentials so password prompt doesn't bork ui
+  print_header
   install_ui
 
   ### save all installed webinterface ports to the ini file

--- a/scripts/ui/update_menu.sh
+++ b/scripts/ui/update_menu.sh
@@ -69,7 +69,7 @@ function update_menu() {
       10)
         do_action "update_crowsnest" "update_ui";;
       11)
-        do_action "update_system" "update_ui";;
+        do_action "upgrade_system_packages" "update_ui";;
       a)
         do_action "update_all" "update_ui";;
       B|b)

--- a/scripts/ui/update_menu.sh
+++ b/scripts/ui/update_menu.sh
@@ -11,7 +11,7 @@
 
 set -e
 
-function update_ui() {
+function update_ui() {  
   top_border
   echo -e "|     ${green}~~~~~~~~~~~~~~ [ Update Menu ] ~~~~~~~~~~~~~~${white}     |"
   hr
@@ -40,6 +40,7 @@ function update_ui() {
 }
 
 function update_menu() {
+  clear -x && sudo -v && clear -x # (re)cache sudo credentials so password prompt doesn't bork ui
   do_action "" "update_ui"
   
   local action

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -381,7 +381,7 @@ function update_system_package_lists() {
     if ! sudo apt-get update --allow-releaseinfo-change &>/dev/null; then
       log_error "Failure while updating package lists!"
       if [[ ! ${silent} == "true" ]]; then error_msg "Updating package lists failed!"; fi
-      exit 1
+      return 1
     else
       log_info "Package lists updated successfully"
       if [[ ! ${silent} == "true" ]]; then status_msg "Updated package lists."; fi

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -375,10 +375,13 @@ function update_system_package_lists() {
   # update if cache is greater than 48 hours old
   if [[ $update_age -gt $((48*60*60)) ]]; then
     if [[ ! $silent ]]; then status_msg "Updating package lists..."; fi
-    if ! sudo apt-get update --allow-releaseinfo-change; then
+    if ! sudo apt-get update --allow-releaseinfo-change &>/dev/null; then
       log_error "Failure while updating package lists!"
       if [[ ! $silent ]]; then error_msg "Updating package lists failed!"; fi
       exit 1
+    else
+      log_info "Package lists updated successfully"
+      if [[ ! $silent ]]; then status_msg "Updated package lists."; fi
     fi
   else
     log_info "Package lists updated recently, skipping update..."

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -20,6 +20,8 @@ function check_euid() {
     echo -e "${red}"
     top_border
     echo -e "|       !!! THIS SCRIPT MUST NOT RUN AS ROOT !!!        |"
+    echo -e "|                                                       |"
+    echo -e "|        It will ask for credentials as needed.         |"
     bottom_border
     echo -e "${white}"
     exit 1


### PR DESCRIPTION
Fixes #334 by first checking if any lists are more than 3 days old. Should be foolproof—if the check returns an error (e.g. if the `find` command or the `/var/lib/apt/lists` directory doesn't exist), it defaults to running the update.