### PR TITLE
feat: allow to install Mainsail/Fluidd without Moonraker

### DIFF
--- a/scripts/fluidd.sh
+++ b/scripts/fluidd.sh
@@ -19,7 +19,21 @@ function install_fluidd() {
   ### exit early if moonraker not found
   if [[ -z $(moonraker_systemd) ]]; then
     local error="Moonraker not installed! Please install Moonraker first!"
-    print_error "${error}" && return
+    print_error "${error}"
+    while true; do
+      read -p "${cyan}###### Install Fluidd without Moonraker? (y/N):${white} " yn
+      case "${yn}" in
+        Y|y|Yes|yes)
+          select_msg "Yes"
+          break;;
+        N|n|No|no|"")
+          select_msg "No"
+          abort_msg "Exiting Fluidd setup ...\n"
+          return;;
+        *)
+          error_msg "Invalid Input!";;
+      esac
+    done
   fi
 
   ### checking dependencies

--- a/scripts/fluidd.sh
+++ b/scripts/fluidd.sh
@@ -16,12 +16,12 @@ set -e
 #===================================================#
 
 function install_fluidd() {
-  ### exit early if moonraker not found
   if [[ -z $(moonraker_systemd) ]]; then
-    local error="Moonraker not installed! Please install Moonraker first!"
+    local error="Moonraker not installed! It's recommended to install Moonraker first!"
     print_error "${error}"
     while true; do
-      read -p "${cyan}###### Install Fluidd without Moonraker? (y/N):${white} " yn
+      local yn
+      read -p "${cyan}###### Proceed to install Fluidd without installing Moonraker? (y/N):${white} " yn
       case "${yn}" in
         Y|y|Yes|yes)
           select_msg "Yes"
@@ -44,7 +44,7 @@ function install_fluidd() {
 
   status_msg "Initializing Fluidd installation ..."
   ### first, we create a backup of the full klipper_config dir - safety first!
-  backup_klipper_config_dir
+  #backup_klipper_config_dir
 
   ### check for other enabled web interfaces
   unset SET_LISTEN_PORT

--- a/scripts/mainsail.sh
+++ b/scripts/mainsail.sh
@@ -19,7 +19,21 @@ function install_mainsail() {
   ### exit early if moonraker not found
   if [[ -z $(moonraker_systemd) ]]; then
     local error="Moonraker not installed! Please install Moonraker first!"
-    print_error "${error}" && return
+    print_error "${error}"
+    while true; do
+      read -p "${cyan}###### Install remote-mode Mainsail without Moonraker? (y/N):${white} " yn
+      case "${yn}" in
+        Y|y|Yes|yes)
+          select_msg "Yes"
+          break;;
+        N|n|No|no|"")
+          select_msg "No"
+          abort_msg "Exiting Mainsail setup ...\n"
+          return;;
+        *)
+          error_msg "Invalid Input!";;
+      esac
+    done
   fi
 
   ### checking dependencies
@@ -157,6 +171,7 @@ function download_mainsail_macros() {
 }
 
 function download_mainsail() {
+  local services
   local url
   url=$(get_mainsail_download_url)
 
@@ -179,8 +194,9 @@ function download_mainsail() {
     exit 1
   fi
 
-  ### check for moonraker multi-instance and if multi-instance was found, enable mainsails remoteMode
-  if [[ $(moonraker_systemd | wc -w) -gt 1 ]]; then
+  ### check for moonraker multi-instance and if no-instance or multi-instance was found, enable mainsails remoteMode
+  services=$(moonraker_systemd)
+  if [[ ( -z "$services" ) || ( $(echo "${services}" | wc -w) -gt 1 ) ]]; then
     enable_mainsail_remotemode
   fi
 }

--- a/scripts/mainsail.sh
+++ b/scripts/mainsail.sh
@@ -16,12 +16,12 @@ set -e
 #===================================================#
 
 function install_mainsail() {
-  ### exit early if moonraker not found
   if [[ -z $(moonraker_systemd) ]]; then
-    local error="Moonraker not installed! Please install Moonraker first!"
+    local error="Moonraker not installed! It's recommended to install Moonraker first!"
     print_error "${error}"
     while true; do
-      read -p "${cyan}###### Install remote-mode Mainsail without Moonraker? (y/N):${white} " yn
+      local yn
+      read -p "${cyan}###### Proceed to install Mainsail without installing Moonraker? (y/N):${white} " yn
       case "${yn}" in
         Y|y|Yes|yes)
           select_msg "Yes"
@@ -196,7 +196,7 @@ function download_mainsail() {
 
   ### check for moonraker multi-instance and if no-instance or multi-instance was found, enable mainsails remoteMode
   services=$(moonraker_systemd)
-  if [[ ( -z "$services" ) || ( $(echo "${services}" | wc -w) -gt 1 ) ]]; then
+  if [[ ( -z "${services}" ) || ( $(echo "${services}" | wc -w) -gt 1 ) ]]; then
     enable_mainsail_remotemode
   fi
 }


### PR DESCRIPTION
This allows the user to install remote mode Mainsail / Fluidd without Moonraker installed in order to setup separated web server from klipper host.

(1) When selecting to install Mainsail or Fluidd without Moonraker installed on localhost , it shows a prompt to confirm installing them without Moonraker.
![image](https://github.com/th33xitus/kiauh/assets/1912821/c1a2435a-4188-4ef9-8895-c592e848fae0)

(2) If installing a Mainsail, this setup remote-mode into the mainsail/config.json.
![image](https://github.com/th33xitus/kiauh/assets/1912821/0472b6cc-7860-41ee-9506-307c4230be4d)

This is a re-implemented version of feature request #258 and closed PR #247.