### PR TITLE
Support of no id micro-controllers

### DIFF
--- a/scripts/flash_klipper.sh
+++ b/scripts/flash_klipper.sh
@@ -318,6 +318,7 @@ function get_usb_id() {
   unset mcu_list
   sleep 1
   mcus=$(find /dev/serial/by-id/* 2>/dev/null)
+  mcus+=" $(find /dev/serial/by-path/* 2>/dev/null)"
 
   for mcu in ${mcus}; do
     mcu_list+=("${mcu}")


### PR DESCRIPTION
Support of no id micro-controllers and let user choose them (appropriate USB) for flashing.
Example, my Debian/Anycubic i3 have no files in /dev/serial/by-id, but it does in /dev/serial/by-path.

(https://www.klipper3d.org/FAQ.html#wheres-my-serial-port)