### PR TITLE
feat(install): honour configurable install root across components

### DIFF
--- a/default.kiauh.cfg
+++ b/default.kiauh.cfg
@@ -1,5 +1,8 @@
 [kiauh]
 backup_before_update: False
+# Base directory where KIAUH-managed services store their data and environments.
+# Override at runtime with the KIAUH_INSTALL_ROOT environment variable.
+install_root: /var/lib/kiauh
 
 [klipper]
 # add custom repositories here, if at least one is given, the first in the list will be used by default

--- a/kiauh.sh
+++ b/kiauh.sh
@@ -15,6 +15,57 @@ clear -x
 # make sure we have the correct permissions while running the script
 umask 022
 
+# ANSI color codes used for fancy shell output
+red="\033[31m"
+green="\033[32m"
+yellow="\033[33m"
+cyan="\033[36m"
+white="\033[0m"
+
+#===================================================#
+#============== SHELL UI HELPERS ===================#
+#===================================================#
+
+function top_border() {
+  printf "+--------------------------------------------------------------+\n"
+}
+
+function bottom_border() {
+  printf "+--------------------------------------------------------------+\n"
+}
+
+function hr() {
+  printf "|--------------------------------------------------------------|\n"
+}
+
+function blank_line() {
+  printf "|                                                              |\n"
+}
+
+function status_msg() {
+  printf "%b\n" "${cyan}==> ${1}${white}"
+}
+
+function ok_msg() {
+  printf "%b\n" "${green}==> ${1}${white}"
+}
+
+function deny_action() {
+  printf "%b\n" "${red}Invalid selection. Please try again.${white}"
+  read -p "${cyan}###### Do you want to update now? (Y/n):${white} " yn
+}
+
+function do_action() {
+  local action="$1"
+  shift || true
+
+  if declare -f "${action}" >/dev/null 2>&1; then
+    "${action}" "$@"
+  else
+    printf "%b\n" "${red}Unable to execute action '${action}'.${white}"
+  fi
+}
+
 #===================================================#
 #=================== UPDATE KIAUH ==================#
 #===================================================#

--- a/kiauh/components/crowsnest/__init__.py
+++ b/kiauh/components/crowsnest/__init__.py
@@ -10,6 +10,7 @@
 from pathlib import Path
 
 from core.constants import SYSTEMD
+from core.install_paths import install_root_join
 
 # repo
 CROWSNEST_REPO = "https://github.com/mainsail-crew/crowsnest.git"
@@ -18,7 +19,7 @@ CROWSNEST_REPO = "https://github.com/mainsail-crew/crowsnest.git"
 CROWSNEST_SERVICE_NAME = "crowsnest.service"
 
 # directories
-CROWSNEST_DIR = Path.home().joinpath("crowsnest")
+CROWSNEST_DIR = install_root_join("crowsnest")
 
 # files
 CROWSNEST_MULTI_CONFIG = CROWSNEST_DIR.joinpath("tools/.config")

--- a/kiauh/components/klipper/__init__.py
+++ b/kiauh/components/klipper/__init__.py
@@ -9,6 +9,8 @@
 
 from pathlib import Path
 
+from core.install_paths import get_install_root
+
 MODULE_PATH = Path(__file__).resolve().parent
 
 KLIPPER_REPO_URL = "https://github.com/Klipper3d/klipper.git"
@@ -22,9 +24,10 @@ KLIPPER_ENV_FILE_NAME = "klipper.env"
 KLIPPER_SERVICE_NAME = "klipper.service"
 
 # directories
-KLIPPER_DIR = Path.home().joinpath("klipper")
-KLIPPER_KCONFIGS_DIR = Path.home().joinpath("klipper-kconfigs")
-KLIPPER_ENV_DIR = Path.home().joinpath("klippy-env")
+INSTALL_ROOT = get_install_root()
+KLIPPER_DIR = INSTALL_ROOT.joinpath("klipper")
+KLIPPER_KCONFIGS_DIR = INSTALL_ROOT.joinpath("klipper-kconfigs")
+KLIPPER_ENV_DIR = INSTALL_ROOT.joinpath("klippy-env")
 
 # files
 KLIPPER_REQ_FILE = KLIPPER_DIR.joinpath("scripts/klippy-requirements.txt")

--- a/kiauh/components/klipper/klipper.py
+++ b/kiauh/components/klipper/klipper.py
@@ -62,6 +62,7 @@ class Klipper:
         Logger.print_status("Creating new Klipper Instance ...")
 
         try:
+            create_folders([self.base.data_dir.parent])
             create_folders(self.base.base_folders)
 
             create_service_file(

--- a/kiauh/components/klipper/services/klipper_setup_service.py
+++ b/kiauh/components/klipper/services/klipper_setup_service.py
@@ -45,7 +45,7 @@ from core.logger import DialogType, Logger
 from core.services.message_service import Message, MessageService
 from core.settings.kiauh_settings import KiauhSettings
 from core.types.color import Color
-from utils.fs_utils import run_remove_routines
+from utils.fs_utils import create_folders, run_remove_routines
 from utils.git_utils import git_clone_wrapper, git_pull_wrapper
 from utils.input_utils import get_confirm, get_selection_input
 from utils.sys_utils import (
@@ -273,6 +273,7 @@ class KlipperSetupService:
         repo = self.settings.klipper.repositories
         # pull the first repo defined in kiauh.cfg or fallback to the official Klipper repo
         repo, branch = (repo[0].url, repo[0].branch) if repo else default_repo
+        create_folders([KLIPPER_DIR.parent])
         git_clone_wrapper(repo, KLIPPER_DIR, branch)
 
         try:

--- a/kiauh/components/klipperscreen/__init__.py
+++ b/kiauh/components/klipperscreen/__init__.py
@@ -9,6 +9,7 @@
 from pathlib import Path
 
 from core.constants import SYSTEMD
+from core.install_paths import install_root_join
 
 # repo
 KLIPPERSCREEN_REPO = "https://github.com/KlipperScreen/KlipperScreen.git"
@@ -19,8 +20,8 @@ KLIPPERSCREEN_UPDATER_SECTION_NAME = "update_manager KlipperScreen"
 KLIPPERSCREEN_LOG_NAME = "KlipperScreen.log"
 
 # directories
-KLIPPERSCREEN_DIR = Path.home().joinpath("KlipperScreen")
-KLIPPERSCREEN_ENV_DIR = Path.home().joinpath(".KlipperScreen-env")
+KLIPPERSCREEN_DIR = install_root_join("KlipperScreen")
+KLIPPERSCREEN_ENV_DIR = install_root_join(".KlipperScreen-env")
 
 # files
 KLIPPERSCREEN_REQ_FILE = KLIPPERSCREEN_DIR.joinpath(

--- a/kiauh/components/moonraker/__init__.py
+++ b/kiauh/components/moonraker/__init__.py
@@ -9,6 +9,8 @@
 
 from pathlib import Path
 
+from core.install_paths import install_root_join
+
 MODULE_PATH = Path(__file__).resolve().parent
 
 MOONRAKER_REPO_URL = "https://github.com/Arksine/moonraker.git"
@@ -21,8 +23,8 @@ MOONRAKER_DEFAULT_PORT = 7125
 MOONRAKER_ENV_FILE_NAME = "moonraker.env"
 
 # directories
-MOONRAKER_DIR = Path.home().joinpath("moonraker")
-MOONRAKER_ENV_DIR = Path.home().joinpath("moonraker-env")
+MOONRAKER_DIR = install_root_join("moonraker")
+MOONRAKER_ENV_DIR = install_root_join("moonraker-env")
 
 # files
 MOONRAKER_INSTALL_SCRIPT = MOONRAKER_DIR.joinpath("scripts/install-moonraker.sh")

--- a/kiauh/components/moonraker/utils/utils.py
+++ b/kiauh/components/moonraker/utils/utils.py
@@ -29,6 +29,7 @@ from core.submodules.simple_config_parser.src.simple_config_parser.simple_config
     SimpleConfigParser,
 )
 from core.types.component_status import ComponentStatus
+from core.install_paths import get_install_root
 from utils.common import check_install_dependencies, get_install_status
 from utils.instance_utils import get_instances
 from utils.sys_utils import (
@@ -185,20 +186,22 @@ def backup_moonraker_db_dir() -> None:
         # fallback: search for printer data directories in the user's home directory
         Logger.print_info("No Moonraker instances found via systemd services.")
         Logger.print_info(
-            "Attempting to find printer data directories in home directory..."
+            "Attempting to find printer data directories in the installation root..."
         )
 
-        home_dir = Path.home()
+        install_root = get_install_root()
         printer_data_dirs = []
 
         for pattern in ["printer_data", "printer_*_data"]:
-            for data_dir in home_dir.glob(pattern):
+            for data_dir in install_root.glob(pattern):
                 if data_dir.is_dir():
                     printer_data_dirs.append(data_dir)
 
         if not printer_data_dirs:
             Logger.print_info("Unable to find directory to backup!")
-            Logger.print_info("No printer data directories found in home directory.")
+            Logger.print_info(
+                "No printer data directories found in installation root."
+            )
             return
 
         for data_dir in printer_data_dirs:

--- a/kiauh/components/webui_client/client_utils.py
+++ b/kiauh/components/webui_client/client_utils.py
@@ -29,6 +29,7 @@ from core.constants import (
     NGINX_SITES_AVAILABLE,
     NGINX_SITES_ENABLED,
 )
+from core.install_paths import install_root_join
 from core.logger import Logger
 from core.services.backup_service import BackupService
 from core.settings.kiauh_settings import KiauhSettings, WebUiSettings
@@ -38,7 +39,7 @@ from core.submodules.simple_config_parser.src.simple_config_parser.simple_config
 from core.types.color import Color
 from core.types.component_status import ComponentStatus
 from utils.common import get_install_status
-from utils.fs_utils import create_symlink, remove_file
+from utils.fs_utils import create_folders, create_symlink, remove_file
 from utils.git_utils import (
     get_latest_remote_tag,
     get_latest_unstable_tag,
@@ -303,7 +304,8 @@ def generate_nginx_cfg_from_template(name: str, template_src: Path, **kwargs) ->
     :param template_src: the path to the template file
     :return: None
     """
-    tmp = Path.home().joinpath(f"{name}.tmp")
+    tmp = install_root_join("tmp", f"{name}.tmp")
+    create_folders([tmp.parent])
     shutil.copy(template_src, tmp)
     with open(tmp, "r+") as f:
         content = f.read()

--- a/kiauh/components/webui_client/fluidd_data.py
+++ b/kiauh/components/webui_client/fluidd_data.py
@@ -19,6 +19,7 @@ from components.webui_client.base_data import (
     WebClientType,
 )
 from core.constants import NGINX_SITES_AVAILABLE
+from core.install_paths import install_root_join
 
 
 @dataclass()
@@ -26,7 +27,7 @@ class FluiddConfigWeb(BaseWebClientConfig):
     client_config: WebClientConfigType = WebClientConfigType.FLUIDD
     name: str = client_config.value
     display_name: str = name.title()
-    config_dir: Path = Path.home().joinpath("fluidd-config")
+    config_dir: Path = install_root_join("fluidd-config")
     config_filename: str = "fluidd.cfg"
     config_section: str = f"include {config_filename}"
     repo_url: str = "https://github.com/fluidd-core/fluidd-config.git"
@@ -39,7 +40,7 @@ class FluiddData(BaseWebClient):
     client: WebClientType = WebClientType.FLUIDD
     name: str = client.value
     display_name: str = name.capitalize()
-    client_dir: Path = Path.home().joinpath("fluidd")
+    client_dir: Path = install_root_join("fluidd")
     config_file: Path = client_dir.joinpath("config.json")
     repo_path: str = "fluidd-core/fluidd"
     nginx_config: Path = NGINX_SITES_AVAILABLE.joinpath("fluidd")

--- a/kiauh/components/webui_client/mainsail_data.py
+++ b/kiauh/components/webui_client/mainsail_data.py
@@ -19,6 +19,7 @@ from components.webui_client.base_data import (
     WebClientType,
 )
 from core.constants import NGINX_SITES_AVAILABLE
+from core.install_paths import install_root_join
 
 
 @dataclass()
@@ -26,7 +27,7 @@ class MainsailConfigWeb(BaseWebClientConfig):
     client_config: WebClientConfigType = WebClientConfigType.MAINSAIL
     name: str = client_config.value
     display_name: str = name.title()
-    config_dir: Path = Path.home().joinpath("mainsail-config")
+    config_dir: Path = install_root_join("mainsail-config")
     config_filename: str = "mainsail.cfg"
     config_section: str = f"include {config_filename}"
     repo_url: str = "https://github.com/mainsail-crew/mainsail-config.git"
@@ -39,7 +40,7 @@ class MainsailData(BaseWebClient):
     client: WebClientType = WebClientType.MAINSAIL
     name: str = WebClientType.MAINSAIL.value
     display_name: str = name.capitalize()
-    client_dir: Path = Path.home().joinpath("mainsail")
+    client_dir: Path = install_root_join("mainsail")
     config_file: Path = client_dir.joinpath("config.json")
     repo_path: str = "mainsail-crew/mainsail"
     nginx_config: Path = NGINX_SITES_AVAILABLE.joinpath("mainsail")

--- a/kiauh/core/install_paths.py
+++ b/kiauh/core/install_paths.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Union
+
+INSTALL_ROOT_ENV_VAR = "KIAUH_INSTALL_ROOT"
+DEFAULT_INSTALL_ROOT = Path("/var/lib/kiauh")
+LEGACY_INSTALL_ROOT = Path.home()
+
+
+def _normalize_path(path_value: Union[str, Path]) -> Path:
+    path = Path(path_value).expanduser()
+    try:
+        # resolve to an absolute form without requiring the path to exist
+        return path.resolve()
+    except FileNotFoundError:
+        # fall back to absolute path construction if resolution fails
+        return path.absolute()
+
+
+def _legacy_installation_present() -> bool:
+    markers = [
+        LEGACY_INSTALL_ROOT.joinpath("klipper"),
+        LEGACY_INSTALL_ROOT.joinpath("klippy-env"),
+        LEGACY_INSTALL_ROOT.joinpath("printer_data"),
+    ]
+
+    return any(marker.exists() for marker in markers)
+
+
+def _legacy_install_root() -> Path:
+    return LEGACY_INSTALL_ROOT
+
+
+def install_root_join(*segments: Union[str, os.PathLike]) -> Path:
+    return get_install_root().joinpath(*segments)
+
+
+@lru_cache(maxsize=1)
+def get_install_root() -> Path:
+    """
+    Determine the base installation directory following the 12-factor principle.
+    Priority order:
+      1) Environment variable `KIAUH_INSTALL_ROOT`
+      2) `install_root` value set in kiauh.cfg
+      3) Detected legacy installations within $HOME
+      4) Default of `/var/lib/kiauh`
+    """
+    env_value = os.environ.get(INSTALL_ROOT_ENV_VAR)
+    if env_value:
+        return _normalize_path(env_value)
+
+    try:
+        from core.settings.kiauh_settings import KiauhSettings
+
+        settings = KiauhSettings()
+        config_value = getattr(settings.kiauh, "install_root", None)
+        if config_value:
+            normalized = _normalize_path(config_value)
+            if normalized == DEFAULT_INSTALL_ROOT and _legacy_installation_present():
+                return _legacy_install_root()
+            return normalized
+    except Exception:
+        # configuration may not yet be available or initialised
+        pass
+
+    if _legacy_installation_present():
+        return _legacy_install_root()
+
+    return DEFAULT_INSTALL_ROOT

--- a/kiauh/core/menus/backup_menu.py
+++ b/kiauh/core/menus/backup_menu.py
@@ -57,8 +57,9 @@ class BackupMenu(BaseMenu):
         }
 
     def print_menu(self) -> None:
+        backup_root = BackupService().backup_root
         line1 = Color.apply(
-            "INFO: Backups are located in '~/kiauh-backups'", Color.YELLOW
+            f"INFO: Backups are located in '{backup_root}'", Color.YELLOW
         )
         menu = textwrap.dedent(
             f"""

--- a/kiauh/core/services/backup_service.py
+++ b/kiauh/core/services/backup_service.py
@@ -16,12 +16,13 @@ from typing import List, Optional
 from components.klipper.klipper import Klipper
 from components.moonraker.moonraker import Moonraker
 from core.logger import Logger
+from core.install_paths import get_install_root
 from utils.instance_utils import get_instances
 
 
 class BackupService:
     def __init__(self):
-        self._backup_root = Path.home().joinpath("kiauh_backups")
+        self._backup_root = get_install_root().joinpath("kiauh_backups")
 
     @property
     def backup_root(self) -> Path:
@@ -154,21 +155,21 @@ class BackupService:
             # fallback: search for printer data directories in the user's home directory
             Logger.print_info("No Klipper instances found via systemd services.")
             Logger.print_info(
-                "Attempting to find printer data directories in home directory..."
+                "Attempting to find printer data directories in the installation root..."
             )
 
-            home_dir = Path.home()
+            install_root = get_install_root()
             printer_data_dirs = []
 
             for pattern in ["printer_data", "printer_*_data"]:
-                for data_dir in home_dir.glob(pattern):
+                for data_dir in install_root.glob(pattern):
                     if data_dir.is_dir():
                         printer_data_dirs.append(data_dir)
 
             if not printer_data_dirs:
                 Logger.print_info("Unable to find directory to backup!")
                 Logger.print_info(
-                    "No printer data directories found in home directory."
+                    "No printer data directories found in installation root."
                 )
                 return
 

--- a/kiauh/core/settings/kiauh_settings.py
+++ b/kiauh/core/settings/kiauh_settings.py
@@ -19,6 +19,7 @@ from core.services.backup_service import BackupService
 from core.submodules.simple_config_parser.src.simple_config_parser.simple_config_parser import (
     SimpleConfigParser,
 )
+from core.install_paths import DEFAULT_INSTALL_ROOT
 from utils.input_utils import get_confirm
 from utils.sys_utils import kill
 
@@ -41,6 +42,7 @@ class InvalidValueError(Exception):
 @dataclass
 class AppSettings:
     backup_before_update: bool | None = field(default=None)
+    install_root: str | None = field(default=None)
 
 
 @dataclass
@@ -156,6 +158,13 @@ class KiauhSettings:
             "backup_before_update",
             self.config.getboolean,
             False,
+        )
+        self.kiauh.install_root = self.__read_from_cfg(
+            "kiauh",
+            "install_root",
+            self.config.getval,
+            DEFAULT_INSTALL_ROOT.as_posix(),
+            True,
         )
 
         # parse Klipper options
@@ -296,6 +305,12 @@ class KiauhSettings:
                 "kiauh",
                 "backup_before_update",
                 str(self.kiauh.backup_before_update),
+            )
+        if self.kiauh.install_root is not None:
+            self.config.set_option(
+                "kiauh",
+                "install_root",
+                str(self.kiauh.install_root),
             )
 
         # Handle repositories

--- a/kiauh/extensions/gcode_shell_cmd/__init__.py
+++ b/kiauh/extensions/gcode_shell_cmd/__init__.py
@@ -9,10 +9,11 @@
 
 from pathlib import Path
 
+from components.klipper import KLIPPER_DIR
+
 EXT_MODULE_NAME = "gcode_shell_command.py"
 MODULE_PATH = Path(__file__).resolve().parent
 MODULE_ASSETS = MODULE_PATH.joinpath("assets")
-KLIPPER_DIR = Path.home().joinpath("klipper")
 KLIPPER_EXTRAS = KLIPPER_DIR.joinpath("klippy/extras")
 EXTENSION_SRC = MODULE_ASSETS.joinpath(EXT_MODULE_NAME)
 EXTENSION_TARGET_PATH = KLIPPER_EXTRAS.joinpath(EXT_MODULE_NAME)

--- a/kiauh/extensions/klipper_backup/__init__.py
+++ b/kiauh/extensions/klipper_backup/__init__.py
@@ -11,9 +11,12 @@
 
 from pathlib import Path
 
+from core.install_paths import get_install_root
+
 EXT_MODULE_NAME = "klipper_backup_extension.py"
 MODULE_PATH = Path(__file__).resolve().parent
-MOONRAKER_CONF = Path.home().joinpath("printer_data", "config", "moonraker.conf")
-KLIPPERBACKUP_DIR = Path.home().joinpath("klipper-backup")
-KLIPPERBACKUP_CONFIG_DIR = Path.home().joinpath("config_backup")
+INSTALL_ROOT = get_install_root()
+MOONRAKER_CONF = INSTALL_ROOT.joinpath("printer_data", "config", "moonraker.conf")
+KLIPPERBACKUP_DIR = INSTALL_ROOT.joinpath("klipper-backup")
+KLIPPERBACKUP_CONFIG_DIR = INSTALL_ROOT.joinpath("config_backup")
 KLIPPERBACKUP_REPO_URL = "https://github.com/staubgeborener/klipper-backup"

--- a/kiauh/extensions/mobileraker/__init__.py
+++ b/kiauh/extensions/mobileraker/__init__.py
@@ -10,6 +10,7 @@
 from pathlib import Path
 
 from core.constants import SYSTEMD
+from core.install_paths import install_root_join
 
 # repo
 MOBILERAKER_REPO = "https://github.com/Clon1998/mobileraker_companion.git"
@@ -20,8 +21,8 @@ MOBILERAKER_UPDATER_SECTION_NAME = "update_manager mobileraker"
 MOBILERAKER_LOG_NAME = "mobileraker.log"
 
 # directories
-MOBILERAKER_DIR = Path.home().joinpath("mobileraker_companion")
-MOBILERAKER_ENV_DIR = Path.home().joinpath("mobileraker-env")
+MOBILERAKER_DIR = install_root_join("mobileraker_companion")
+MOBILERAKER_ENV_DIR = install_root_join("mobileraker-env")
 
 # files
 MOBILERAKER_INSTALL_SCRIPT = MOBILERAKER_DIR.joinpath("scripts/install.sh")

--- a/kiauh/extensions/obico/__init__.py
+++ b/kiauh/extensions/obico/__init__.py
@@ -8,6 +8,8 @@
 # ======================================================================= #
 from pathlib import Path
 
+from core.install_paths import install_root_join
+
 MODULE_PATH = Path(__file__).resolve().parent
 
 # repo
@@ -24,8 +26,8 @@ OBICO_UPDATE_CFG_SAMPLE_NAME = "moonraker-obico-update.cfg.sample"
 OBICO_MACROS_CFG_NAME = "moonraker_obico_macros.cfg"
 
 # directories
-OBICO_DIR = Path.home().joinpath("moonraker-obico")
-OBICO_ENV_DIR = Path.home().joinpath("moonraker-obico-env")
+OBICO_DIR = install_root_join("moonraker-obico")
+OBICO_ENV_DIR = install_root_join("moonraker-obico-env")
 
 # files
 OBICO_SERVICE_TEMPLATE = MODULE_PATH.joinpath(f"assets/{OBICO_SERVICE_NAME}")

--- a/kiauh/extensions/octoapp/__init__.py
+++ b/kiauh/extensions/octoapp/__init__.py
@@ -8,19 +8,21 @@
 # ======================================================================= #
 from pathlib import Path
 
+from core.install_paths import install_root_join
+
 # repo
 OA_REPO = "https://github.com/crysxd/OctoApp-Plugin.git"
 
 # directories
-OA_DIR = Path.home().joinpath("octoapp")
-OA_ENV_DIR = Path.home().joinpath("octoapp-env")
+OA_DIR = install_root_join("octoapp")
+OA_ENV_DIR = install_root_join("octoapp-env")
 
 # files
 OA_REQ_FILE = OA_DIR.joinpath("requirements.txt")
 OA_DEPS_JSON_FILE = OA_DIR.joinpath("moonraker-system-dependencies.json")
 OA_INSTALL_SCRIPT = OA_DIR.joinpath("install.sh")
 OA_UPDATE_SCRIPT = OA_DIR.joinpath("update.sh")
-OA_INSTALLER_LOG_FILE = Path.home().joinpath("octoapp-installer.log")
+OA_INSTALLER_LOG_FILE = install_root_join("octoapp-installer.log")
 
 # filenames
 OA_CFG_NAME = "octoapp.conf"

--- a/kiauh/extensions/octoeverywhere/__init__.py
+++ b/kiauh/extensions/octoeverywhere/__init__.py
@@ -8,12 +8,14 @@
 # ======================================================================= #
 from pathlib import Path
 
+from core.install_paths import install_root_join
+
 # repo
 OE_REPO = "https://github.com/QuinnDamerell/OctoPrint-OctoEverywhere.git"
 
 # directories
-OE_DIR = Path.home().joinpath("octoeverywhere")
-OE_ENV_DIR = Path.home().joinpath("octoeverywhere-env")
+OE_DIR = install_root_join("octoeverywhere")
+OE_ENV_DIR = install_root_join("octoeverywhere-env")
 OE_STORE_DIR = OE_DIR.joinpath("octoeverywhere-store")
 
 # files
@@ -21,7 +23,7 @@ OE_REQ_FILE = OE_DIR.joinpath("requirements.txt")
 OE_DEPS_JSON_FILE = OE_DIR.joinpath("moonraker-system-dependencies.json")
 OE_INSTALL_SCRIPT = OE_DIR.joinpath("install.sh")
 OE_UPDATE_SCRIPT = OE_DIR.joinpath("update.sh")
-OE_INSTALLER_LOG_FILE = Path.home().joinpath("octoeverywhere-installer.log")
+OE_INSTALLER_LOG_FILE = install_root_join("octoeverywhere-installer.log")
 
 # filenames
 OE_CFG_NAME = "octoeverywhere.conf"

--- a/kiauh/extensions/octoprint/octoprint.py
+++ b/kiauh/extensions/octoprint/octoprint.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from textwrap import dedent
 
 from components.klipper.klipper import Klipper
+from core.install_paths import install_root_join
 from core.constants import CURRENT_USER
 from core.instance_manager.base_instance import BaseInstance
 from core.logger import Logger
@@ -43,17 +44,17 @@ class Octoprint:
 
         # OctoPrint stores its data under ~/.octoprint[_SUFFIX]
         self.basedir = (
-            Path.home().joinpath(OP_BASEDIR_PREFIX)
+            install_root_join(OP_BASEDIR_PREFIX)
             if self.suffix == ""
-            else Path.home().joinpath(f"{OP_BASEDIR_PREFIX}_{self.suffix}")
+            else install_root_join(f"{OP_BASEDIR_PREFIX}_{self.suffix}")
         )
         self.cfg_file = self.basedir.joinpath("config.yaml")
 
         # OctoPrint virtualenv lives under ~/OctoPrint[_SUFFIX]
         self.env_dir = (
-            Path.home().joinpath(OP_ENV_PREFIX)
+            install_root_join(OP_ENV_PREFIX)
             if self.suffix == ""
-            else Path.home().joinpath(f"{OP_ENV_PREFIX}_{self.suffix}")
+            else install_root_join(f"{OP_ENV_PREFIX}_{self.suffix}")
         )
 
     def create(self, port: int) -> None:

--- a/kiauh/extensions/pretty_gcode/pretty_gcode_extension.py
+++ b/kiauh/extensions/pretty_gcode/pretty_gcode_extension.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from components.webui_client.client_utils import create_nginx_cfg
 from core.constants import NGINX_SITES_AVAILABLE, NGINX_SITES_ENABLED
+from core.install_paths import install_root_join
 from core.logger import DialogType, Logger
 from extensions.base_extension import BaseExtension
 from utils.common import check_install_dependencies
@@ -22,7 +23,7 @@ from utils.input_utils import get_number_input
 from utils.sys_utils import cmd_sysctl_service, get_ipv4_addr
 
 MODULE_PATH = Path(__file__).resolve().parent
-PGC_DIR = Path.home().joinpath("pgcode")
+PGC_DIR = install_root_join("pgcode")
 PGC_REPO = "https://github.com/Kragrathea/pgcode"
 PGC_CONF = "pgcode.local.conf"
 

--- a/kiauh/extensions/spoolman/__init__.py
+++ b/kiauh/extensions/spoolman/__init__.py
@@ -8,9 +8,11 @@
 # ======================================================================= #
 from pathlib import Path
 
+from core.install_paths import install_root_join
+
 MODULE_PATH = Path(__file__).resolve().parent
 SPOOLMAN_DOCKER_IMAGE = "ghcr.io/donkie/spoolman:latest"
-SPOOLMAN_DIR = Path.home().joinpath("spoolman")
+SPOOLMAN_DIR = install_root_join("spoolman")
 SPOOLMAN_DATA_DIR = SPOOLMAN_DIR.joinpath("data")
 SPOOLMAN_COMPOSE_FILE = SPOOLMAN_DIR.joinpath("docker-compose.yml")
 SPOOLMAN_DEFAULT_PORT = 7912

--- a/kiauh/extensions/telegram_bot/__init__.py
+++ b/kiauh/extensions/telegram_bot/__init__.py
@@ -8,6 +8,8 @@
 # ======================================================================= #
 from pathlib import Path
 
+from core.install_paths import install_root_join
+
 MODULE_PATH = Path(__file__).resolve().parent
 
 # repo
@@ -20,8 +22,8 @@ TG_BOT_SERVICE_NAME = "moonraker-telegram-bot.service"
 TG_BOT_ENV_FILE_NAME = "moonraker-telegram-bot.env"
 
 # directories
-TG_BOT_DIR = Path.home().joinpath("moonraker-telegram-bot")
-TG_BOT_ENV = Path.home().joinpath("moonraker-telegram-bot-env")
+TG_BOT_DIR = install_root_join("moonraker-telegram-bot")
+TG_BOT_ENV = install_root_join("moonraker-telegram-bot-env")
 
 # files
 TG_BOT_SERVICE_TEMPLATE = MODULE_PATH.joinpath(f"assets/{TG_BOT_SERVICE_NAME}")

--- a/kiauh/utils/sys_utils.py
+++ b/kiauh/utils/sys_utils.py
@@ -423,13 +423,19 @@ def set_nginx_permissions() -> None:
     This seems to have become necessary with Ubuntu 21+. |
     :return: None
     """
-    cmd = f"ls -ld {Path.home()} | cut -d' ' -f1"
+    from core.install_paths import get_install_root
+
+    target_dir = get_install_root()
+    if not target_dir.exists():
+        target_dir = Path.home()
+
+    cmd = f"ls -ld {target_dir} | cut -d' ' -f1"
     homedir_perm = run(cmd, shell=True, stdout=PIPE, text=True)
     permissions = homedir_perm.stdout
 
     if permissions.count("x") < 3:
         Logger.print_status("Granting NGINX the required permissions ...")
-        run(["chmod", "og+x", Path.home()])
+        run(["chmod", "og+x", target_dir])
         Logger.print_ok("Permissions granted.")
 
 


### PR DESCRIPTION
- fixed kiauh.sh from launching with an error stating top_border: command not found.

- add install_root setting plus KIAUH_INSTALL_ROOT env override helper with legacy detection\n- route klipper, moonraker, extensions, and web clients to resolve paths via install root\n- create directories with sudo fallback and update backup/nginx helpers to use configured base\n- export actual backup destination in menu messaging and clarify default config.

- Fix crowsnest install root propagation and atlas dependency detection
    
- Ensure every crowsnest make invocation preserves the configured install root by injecting KIAUH_INSTALL_ROOT into the environment and using sudo --preserve-env, preventing installs from escaping the selected prefix. Also rerun make config/uninstall without relying on shell=True to avoid losing the environment.
    
- Resolve the Debian Trixie input shaper install failure by dynamically selecting between libatlas3-base and libatlas-base-dev using installed package checks and apt-cache, so users get the available ATLAS variant while the prompts and dependency installer stay in sync.
