### PR TITLE
refactor: remove dependency on libatlas-base-dev

### DIFF
--- a/kiauh/components/klipper/klipper_utils.py
+++ b/kiauh/components/klipper/klipper_utils.py
@@ -237,7 +237,6 @@ def install_input_shaper_deps() -> None:
             "If you agree, the following additional system packages will be installed:",
             "● python3-numpy",
             "● python3-matplotlib",
-            "● libatlas-base-dev",
             "● libopenblas-dev",
             "\n\n",
             "Also, the following Python package will be installed:",
@@ -253,7 +252,6 @@ def install_input_shaper_deps() -> None:
     apt_deps = (
         "python3-numpy",
         "python3-matplotlib",
-        "libatlas-base-dev",
         "libopenblas-dev",
     )
     check_install_dependencies({*apt_deps})


### PR DESCRIPTION
`libatlas-base-dev` was removed in Debian Trixie, so it's effectively no longer available for recent Pi installs. It's apparently [considered obsoleted](https://github.com/numpy/numpy/issues/29108#issuecomment-2929813407) and `libopenblas-dev` covers the same ground anyways. Numpy installs and works fine with the explicit dependency removed (`~/klippy-env/bin/python -c 'import numpy;'`), and this remove a tripping point for new uers.

Resolves #733