### PR TITLE
feat(gcode_shell_command): allowing for expanding env vars

### DIFF
--- a/kiauh/extensions/gcode_shell_cmd/assets/gcode_shell_command.py
+++ b/kiauh/extensions/gcode_shell_cmd/assets/gcode_shell_command.py
@@ -16,6 +16,7 @@ class ShellCommand:
         self.gcode = self.printer.lookup_object("gcode")
         cmd = config.get("command")
         cmd = os.path.expanduser(cmd)
+        cmd = os.path.expandvars(cmd)
         self.command = shlex.split(cmd)
         self.timeout = config.getfloat("timeout", 2.0, above=0.0)
         self.verbose = config.getboolean("verbose", True)


### PR DESCRIPTION
Requesting consideration for allowing for [environmental vars](https://docs.python.org/3/library/os.path.html#os.path.expandvars) to be evaluated in addition to expanduser. 

Currently, for expanduser to work to the script it's calling has to be executable which seems natural and works as expected so long as you are only calling it with something like this:

```
[gcode_shell_command meow]
command: ~/meow.sh
```

So long as meow.sh is executable, it'll work as expected. If it's not executable, it'll result in an error...which makes sense in this context. But if it's a none executable script and you try this:

```
[gcode_shell_command meow]
command: /bin/bash ~/meow.sh
```

It'll give you an error because it's looking for something literally called ~/meow. 

With expandvars, this allows more flexibility. 

```
[gcode_shell_command meow]
command: /bin/bash $HOME/meow.sh
```

Now, we can execute a script that isn't executable but instead is processed by /bin/bash and executed. 

Further, this opens up other environment vars to klipper which may be useful for other interesting tasks. 

My immediate use case and scenario is I am working on for the formbot explorer 3d printer on a none standard image of my own building. I'm going to submit a PR to allow for best practices concerning executing scripts via bash and using the $HOME variable for the path to the script instead of the currently implemented `sh /full/user/path/to/script`. Since my user doesn't match that btt cb2 image user, I can't use these scripts natively. This change allows that better flexibility. 

I've tested the change locally and it works as expected. I've tried some regression testing with the previous functionality and that continues to work as expected for executing scripts that have the correct mode and uses `~` for pathing. 

Thanks for the consideration. 
