### PR TITLE
fix(fs_utils): enhance check_file_exist to follow symlinks and limit recursion

### DIFF
--- a/kiauh/utils/fs_utils.py
+++ b/kiauh/utils/fs_utils.py
@@ -24,13 +24,16 @@ from core.logger import Logger
 
 def check_file_exist(file_path: Path, sudo=False) -> bool:
     """
-    Helper function for checking the existence of a file |
+    Helper function for checking the existence of a file.
+    Also works with symlinks (returns False if broken) |
     :param file_path: the absolute path of the file to check
     :param sudo: use sudo if required
     :return: True, if file exists, otherwise False
     """
     if sudo:
-        command = ["sudo", "find", file_path.as_posix()]
+        # -L forces find to follow symlinks
+        # -maxdepth = 0 avoids loosing time if `file_path` is a directory
+        command = ["sudo", "find", "-L", "-maxdepth", "0", file_path.as_posix()]
         try:
             check_output(command, stderr=DEVNULL)
             return True


### PR DESCRIPTION
Addresses an inconsistency in how `check_file_exist` handles symbolic links depending on the sudo flag.

Previously, sudo=True (using find) would return True for a broken symlink, while sudo=False (using Path.exists()) would return False. I found out the hard way while working on #752 

Aligned both statements by forcing the sudo branch to resolve symlinks using the -L flag.

Furthermore, as far as I could tell, `check_file_exist` is only supposed to be used on exactly matching file names/paths. I added -maxdepth 0 to the flags of the find command in order to prevent recursion. As far as I understand, it should marginally improve performance..

Tested locally without issues by installing/removing Moonraker and Gcode_Shell_Extension