### PR TITLE
fix(gcode_shell_cmd): update comment to clarify config directory usage

### DIFF
--- a/kiauh/extensions/gcode_shell_cmd/gcode_shell_cmd_extension.py
+++ b/kiauh/extensions/gcode_shell_cmd/gcode_shell_cmd_extension.py
@@ -97,7 +97,7 @@ class GcodeShellCmdExtension(BaseExtension):
 
     def install_example_cfg(self, instances: List[Klipper]):
         cfg_dirs = [instance.base.cfg_dir for instance in instances]
-        # copy extension to klippy/extras
+        # copy extension to config directories
         for cfg_dir in cfg_dirs:
             Logger.print_status(f"Create shell_command.cfg in '{cfg_dir}' ...")
             if check_file_exist(cfg_dir.joinpath("shell_command.cfg")):


### PR DESCRIPTION
Corrected a comment in `gcode_shell_cmd_extension.py` that incorrectly described the destination of the file copy operation. 

The code copies the example config to the Klipper config directory, not the `klippy/extras` folder. This seems to be a minor legacy error from the initial Python rewrite.