### PR TITLE
fix(backup_service): backup methods use proper paths (#769)

### DIFF
--- a/kiauh/core/services/backup_service.py
+++ b/kiauh/core/services/backup_service.py
@@ -70,9 +70,7 @@ class BackupService:
             backup_dir.mkdir(parents=True, exist_ok=True)
             shutil.copy2(source_path, backup_dir.joinpath(filename))
 
-            Logger.print_ok(
-                f"Successfully backed up '{source_path}' to '{backup_dir}'"
-            )
+            Logger.print_ok(f"Successfully backed up '{source_path}' to '{backup_dir}'")
             return True
 
         except Exception as e:
@@ -134,27 +132,27 @@ class BackupService:
     ################################################
 
     def backup_printer_cfg(self):
+        """Backup printer.cfg files of all Klipper instances.
+        Files are backed up to:
+        <backup_root>/<instance_data_dir_name>/printer_<timestamp>.cfg"""
         klipper_instances: List[Klipper] = get_instances(Klipper)
         for instance in klipper_instances:
-            target_path: Path = self._backup_root.joinpath(
-                instance.data_dir.name, f"config_{self.timestamp}"
-            )
+            target_path: Path = self._backup_root.joinpath(instance.data_dir.name)
             self.backup_file(
                 source_path=instance.cfg_file,
                 target_path=target_path,
-                target_name=instance.cfg_file.name,
             )
 
     def backup_moonraker_conf(self):
+        """Backup moonraker.conf files of all Moonraker instances.
+        Files are backed up to:
+        <backup_root>/<instance_data_dir_name>/moonraker_<timestamp>.conf"""
         moonraker_instances: List[Moonraker] = get_instances(Moonraker)
         for instance in moonraker_instances:
-            target_path: Path = self._backup_root.joinpath(
-                instance.data_dir.name, f"config_{self.timestamp}"
-            )
+            target_path: Path = self._backup_root.joinpath(instance.data_dir.name)
             self.backup_file(
                 source_path=instance.cfg_file,
                 target_path=target_path,
-                target_name=instance.cfg_file.name,
             )
 
     def backup_printer_config_dir(self) -> None:

--- a/kiauh/core/services/backup_service.py
+++ b/kiauh/core/services/backup_service.py
@@ -68,9 +68,10 @@ class BackupService:
                 backup_dir = self._backup_root.joinpath(target_path)
 
             backup_dir.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(source_path, backup_dir.joinpath(filename))
+            destination_path = backup_dir.joinpath(filename)
+            shutil.copy2(source_path, destination_path)
 
-            Logger.print_ok(f"Successfully backed up '{source_path}' to '{backup_dir}'")
+            Logger.print_ok(f"Successfully backed up '{source_path}' to '{destination_path}'")
             return True
 
         except Exception as e:

--- a/kiauh/core/services/backup_service.py
+++ b/kiauh/core/services/backup_service.py
@@ -71,7 +71,9 @@ class BackupService:
             destination_path = backup_dir.joinpath(filename)
             shutil.copy2(source_path, destination_path)
 
-            Logger.print_ok(f"Successfully backed up '{source_path}' to '{destination_path}'")
+            Logger.print_ok(
+                f"Successfully backed up '{source_path}' to '{destination_path}'"
+            )
             return True
 
         except Exception as e:
@@ -135,7 +137,8 @@ class BackupService:
     def backup_printer_cfg(self):
         """Backup printer.cfg files of all Klipper instances.
         Files are backed up to:
-        <backup_root>/<instance_data_dir_name>/printer_<timestamp>.cfg"""
+        {backup_root}/{instance_data_dir_name}/printer_{timestamp}.cfg
+        """
         klipper_instances: List[Klipper] = get_instances(Klipper)
         for instance in klipper_instances:
             target_path: Path = self._backup_root.joinpath(instance.data_dir.name)
@@ -147,7 +150,8 @@ class BackupService:
     def backup_moonraker_conf(self):
         """Backup moonraker.conf files of all Moonraker instances.
         Files are backed up to:
-        <backup_root>/<instance_data_dir_name>/moonraker_<timestamp>.conf"""
+        {backup_root}/{instance_data_dir_name}/moonraker_{timestamp}.conf
+        """
         moonraker_instances: List[Moonraker] = get_instances(Moonraker)
         for instance in moonraker_instances:
             target_path: Path = self._backup_root.joinpath(instance.data_dir.name)

--- a/kiauh/core/services/backup_service.py
+++ b/kiauh/core/services/backup_service.py
@@ -68,11 +68,11 @@ class BackupService:
                 backup_dir = self._backup_root.joinpath(target_path)
 
             backup_dir.mkdir(parents=True, exist_ok=True)
-            destination_path = backup_dir.joinpath(filename)
-            shutil.copy2(source_path, destination_path)
+            target_path = backup_dir.joinpath(filename)
+            shutil.copy2(source_path, target_path)
 
             Logger.print_ok(
-                f"Successfully backed up '{source_path}' to '{destination_path}'"
+                f"Successfully backed up '{source_path}' to '{target_path}'"
             )
             return True
 


### PR DESCRIPTION
Fixes #769 

Updated 

- `backup_printer_cfg` > docstring + logic
- `backup_moonraker_conf` > docstring + logic
- `backup_file` > proper path for verbose output

`target_path`: removed the code that appended `config_{timestamp}` 

`target_name`: removed the argument as it is was a duplicate of the subcall's logic. The `backup_file` method already contains logic to generate a timestamped filename ({stem}_{timestamp}{suffix}) if target_name is omitted. 

---

Added a simple docstring to both methods, which could maybe be enhanced ? 

---

Before: 
```
Creating backup of /home/trident/printer_data/config/printer.cfg ...
[OK] Successfully backed up to '/home/trident/kiauh_backups/printer_data/config_20260121-021909'
```

Now:
```
Creating backup of /home/trident/printer_data/config/printer.cfg ...
[OK] Successfully backed up to '/home/trident/kiauh_backups/printer_data/printer_20260121-021909.cfg'
```

---

Edit: modified the docstring to use `{ }` instead of `< >`, as the brackets where being rendered in the docstrings (as html headers..)

Edit 2: changed from `destination_path` to `target_path` to align with the rest of the project