### PR TITLE
fix(extensions_menu): prevent extension index collisions during loading

### DIFF
--- a/kiauh/extensions/__init__.py
+++ b/kiauh/extensions/__init__.py
@@ -10,3 +10,4 @@
 from pathlib import Path
 
 EXTENSION_ROOT = Path(__file__).resolve().parents[1].joinpath("extensions")
+GITHUB_ISSUES_URL = "https://github.com/dw-0/kiauh/issues"

--- a/kiauh/extensions/extensions_menu.py
+++ b/kiauh/extensions/extensions_menu.py
@@ -56,6 +56,21 @@ class ExtensionsMenu(BaseMenu):
                 with open(metadata_json, "r") as m:
                     # read extension metadata from json
                     metadata = json.load(m).get("metadata")
+                    index = str(metadata.get("index"))
+
+                    # Prevent collisions where one extension silently overrides another.
+                    if index in ext_dict:
+                        existing_name = ext_dict[index].metadata.get("display_name")
+                        duplicate_name = metadata.get("display_name")
+                        print(
+                            "Failed loading extension"
+                            f" {ext}: duplicate index '{index}'"
+                            f" already used by '{existing_name}'."
+                            f" Skipping '{duplicate_name}'."
+                        )
+                        continue
+
+                    int(index)
                     module_name = metadata.get("module")
                     module_path = f"kiauh.extensions.{ext.name}.{module_name}"
 
@@ -73,9 +88,16 @@ class ExtensionsMenu(BaseMenu):
 
                     # instantiate the extension with its metadata and add to dict
                     ext_instance: BaseExtension = ext_class(metadata)
-                    ext_dict[f"{metadata.get('index')}"] = ext_instance
+                    ext_dict[index] = ext_instance
 
-            except (IOError, json.JSONDecodeError, ImportError) as e:
+            except (
+                IOError,
+                json.JSONDecodeError,
+                ImportError,
+                TypeError,
+                ValueError,
+                AttributeError,
+            ) as e:
                 print(f"Failed loading extension {ext}: {e}")
 
         return dict(sorted(ext_dict.items(), key=lambda x: int(x[0])))

--- a/kiauh/extensions/extensions_menu.py
+++ b/kiauh/extensions/extensions_menu.py
@@ -19,7 +19,7 @@ from core.logger import Logger
 from core.menus import Option
 from core.menus.base_menu import BaseMenu
 from core.types.color import Color
-from extensions import EXTENSION_ROOT
+from extensions import EXTENSION_ROOT, GITHUB_ISSUES_URL
 from extensions.base_extension import BaseExtension
 
 
@@ -62,11 +62,12 @@ class ExtensionsMenu(BaseMenu):
                     if index in ext_dict:
                         existing_name = ext_dict[index].metadata.get("display_name")
                         duplicate_name = metadata.get("display_name")
-                        print(
+                        Logger.print_warn(
                             "Failed loading extension"
                             f" {ext}: duplicate index '{index}'"
                             f" already used by '{existing_name}'."
                             f" Skipping '{duplicate_name}'."
+                            f" Please report this at {GITHUB_ISSUES_URL}."
                         )
                         continue
 
@@ -98,7 +99,10 @@ class ExtensionsMenu(BaseMenu):
                 ValueError,
                 AttributeError,
             ) as e:
-                print(f"Failed loading extension {ext}: {e}")
+                Logger.print_warn(
+                    f"Failed loading extension {ext}: {e}. "
+                    f"Please report this at {GITHUB_ISSUES_URL}."
+                )
 
         return dict(sorted(ext_dict.items(), key=lambda x: int(x[0])))
 


### PR DESCRIPTION
Enhances the robustness of the extension discovery process in `kiauh/extensions/extensions_menu.py` by improving error handling and preventing index collisions when loading extensions.

* Added a check to prevent loading multiple extensions with the same `index`, ensuring that one extension cannot silently override another. If a duplicate index is detected, a descriptive error message is printed and the duplicate is skipped.

* Expanded the exception handling in the extension loading process to catch additional error types, including `TypeError`, `ValueError`, and `AttributeError`, making the process more robust against malformed or incompatible extensions.

* Refactored the code to consistently use the `index` variable when adding extensions to `ext_dict`, improving code clarity.