### PR TITLE
refactor: use correct crowsnest branch for v5 and future releases

### DIFF
--- a/kiauh/components/crowsnest/crowsnest.py
+++ b/kiauh/components/crowsnest/crowsnest.py
@@ -47,7 +47,7 @@ from utils.sys_utils import (
 
 def install_crowsnest() -> None:
     # Step 1: Clone crowsnest repo
-    git_clone_wrapper(CROWSNEST_REPO, CROWSNEST_DIR, "master")
+    git_clone_wrapper(CROWSNEST_REPO, CROWSNEST_DIR)
 
     # Step 2: Install dependencies
     check_install_dependencies({"make"})


### PR DESCRIPTION
Crowsnest changed it's branch naming scheme v5 and future releases will name the branch after the major release. This change removes the branch so that it will default to the default branch set in GitHub.