### PR TITLE
fix(switch_repo): honor use_python_binary when recreating venv

### DIFF
--- a/kiauh/procedures/switch_repo.py
+++ b/kiauh/procedures/switch_repo.py
@@ -48,6 +48,11 @@ class RepoSwitchFailedException(Exception):
 def run_switch_repo_routine(
     name: Literal["klipper", "moonraker"], repo_url: str, branch: str
 ) -> None:
+    if name not in ("klipper", "moonraker"):
+        raise ValueError(
+            f"Invalid name: {name!r}. Must be 'klipper' or 'moonraker'."
+        )
+        
     repo_dir: Path = KLIPPER_DIR if name == "klipper" else MOONRAKER_DIR
     env_dir: Path = KLIPPER_ENV_DIR if name == "klipper" else MOONRAKER_ENV_DIR
     req_file = KLIPPER_REQ_FILE if name == "klipper" else MOONRAKER_REQ_FILE
@@ -90,13 +95,13 @@ def run_switch_repo_routine(
 
         # step 6: recreate python virtualenv
         Logger.print_status(f"Recreating {_type.__name__} virtualenv ...")
+
         settings = KiauhSettings()
         if name == "klipper":
             use_python_binary = settings.klipper.use_python_binary
         elif name == "moonraker":
             use_python_binary = settings.moonraker.use_python_binary
-        else:
-            raise AssertionError("unreachable")
+            
         if not create_python_venv(
             env_dir, force=True, use_python_binary=use_python_binary
         ):

--- a/kiauh/procedures/switch_repo.py
+++ b/kiauh/procedures/switch_repo.py
@@ -31,6 +31,7 @@ from components.moonraker.services.moonraker_setup_service import (
 from core.instance_manager.instance_manager import InstanceManager
 from core.logger import Logger
 from core.services.backup_service import BackupService
+from core.settings.kiauh_settings import KiauhSettings
 from utils.git_utils import GitException, git_clone_wrapper
 from utils.instance_utils import get_instances
 from utils.sys_utils import (
@@ -89,7 +90,16 @@ def run_switch_repo_routine(
 
         # step 6: recreate python virtualenv
         Logger.print_status(f"Recreating {_type.__name__} virtualenv ...")
-        if not create_python_venv(env_dir, force=True):
+        settings = KiauhSettings()
+        if name == "klipper":
+            use_python_binary = settings.klipper.use_python_binary
+        elif name == "moonraker":
+            use_python_binary = settings.moonraker.use_python_binary
+        else:
+            raise AssertionError("unreachable")
+        if not create_python_venv(
+            env_dir, force=True, use_python_binary=use_python_binary
+        ):
             raise GitException(f"Failed to recreate virtualenv for {_type.__name__}")
         else:
             install_python_requirements(env_dir, req_file)


### PR DESCRIPTION
Fixes the issue where `use_python_binary` in `kiauh.cfg` is ignored when
changing the repository via "Switch Klipper / Moonraker source repository".

`run_switch_repo_routine` calls `create_python_venv(env_dir, force=True)`
without forwarding `use_python_binary`, so the recreated venv always uses
`/usr/bin/python3` regardless of config. This aligns `switch_repo` with
`KlipperSetupService.__install_deps` and
`MoonrakerSetupService.__install_deps`, which already pass
`settings.<component>.use_python_binary` to `create_python_venv`.

No behavior change when `use_python_binary` is unset — `create_python_venv`
still falls back to `/usr/bin/python3`.